### PR TITLE
Local/global rotation/translation + Stop action with escape + Consume events

### DIFF
--- a/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
@@ -121,8 +121,10 @@ public static class BlenderHelper
 
     public static KeyCode AxisKeycode(Event e)
     {
-        if (e.type == EventType.KeyDown && (e.keyCode == KeyCode.X || e.keyCode == KeyCode.Y || e.keyCode == KeyCode.Z))
+        if (e.type == EventType.KeyDown && (e.keyCode == KeyCode.X || e.keyCode == KeyCode.Y || e.keyCode == KeyCode.Z)) {
+            e.Use();
             return e.keyCode;
+        }
         return KeyCode.None;
     }
     public static void AppendUnitNumber(Event e, ref string UnitNumber)

--- a/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
@@ -100,12 +100,23 @@ public static class BlenderHelper
     }
     public static bool CancelKeyPressed(Event e)
     {
-        return e.type == EventType.KeyDown && (e.keyCode == KeyCode.Return || e.keyCode == KeyCode.KeypadEnter)
-       || (e.type == EventType.MouseDown && e.button == 0);
+        bool cancel = e.type == EventType.KeyDown && (e.keyCode == KeyCode.Return || e.keyCode == KeyCode.KeypadEnter)
+            || (e.type == EventType.MouseDown && e.button == 0);
+        if (cancel) 
+        {
+            e.Use();
+        }
+        return cancel;
     }
     public static bool RevertKeyPressed(Event e)
     {
-        return e.type == EventType.MouseDown && e.button == 1;
+        bool revert = (e.type == EventType.KeyDown && e.keyCode == KeyCode.Escape)
+            || (e.type == EventType.MouseDown && e.button == 1);
+        if (revert) 
+        {
+            e.Use();
+        }
+        return revert;
     }
 
     public static KeyCode AxisKeycode(Event e)

--- a/Assets/UnityBlenderControl/Editor/BlenderMoveEditor.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderMoveEditor.cs
@@ -50,8 +50,9 @@ public class BlenderMoveEditor : Editor
                 initialOffset = initialPosition - GetWorldMouse(((Transform)target).position);
                 IntialObjectPosition = initialPosition;
 
-
-                ObjectAxis = BlenderHelper.GetObjectAxis(targetObj, selectedAxis);
+                ObjectAxis = Tools.pivotRotation == PivotRotation.Local
+                    ? BlenderHelper.GetObjectAxis((Transform)target, selectedAxis)
+                    :  selectedAxis;
                 WorldAxis = selectedAxis;
             }
 

--- a/Assets/UnityBlenderControl/Editor/BlenderRotateEditor.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotateEditor.cs
@@ -21,7 +21,7 @@ public class BlenderRotateEditor : Editor
             Undo.RegisterCompleteObjectUndo((Transform)target, "Rotate Object");
             // Activate scale mode when "R" key is pressed
             CurrentTransformMode = TransformMode.Rotate;
-            initialRotation = ((Transform)target).localEulerAngles;
+            initialRotation = ((Transform)target).eulerAngles;
             mouseStartPosition = e.mousePosition;
             selectedAxis = Vector3.one;
 
@@ -40,8 +40,10 @@ public class BlenderRotateEditor : Editor
             {
                 selectedAxis = BlenderHelper.GetAxisVector(AxisCode);
                 IntialObjectPosition = ((Transform)target).position;
-                ((Transform)target).localRotation = Quaternion.Euler(initialRotation);
-                ObjectAxis = BlenderHelper.GetObjectAxis((Transform)target, selectedAxis);
+                ((Transform)target).rotation = Quaternion.Euler(initialRotation);
+                ObjectAxis = Tools.pivotRotation == PivotRotation.Local
+                    ? BlenderHelper.GetObjectAxis((Transform)target, selectedAxis)
+                    :  selectedAxis;
                 WorldAxis = selectedAxis;
             }
             if (!RotateByAngle())
@@ -59,7 +61,7 @@ public class BlenderRotateEditor : Editor
             if (BlenderHelper.RevertKeyPressed(e))
             {
                 // Revert changes and deactivate scale mode on right mouse button
-                ((Transform)target).localRotation = Quaternion.Euler(initialRotation);
+                ((Transform)target).rotation = Quaternion.Euler(initialRotation);
 
                 CurrentTransformMode = TransformMode.None;
             }
@@ -92,7 +94,7 @@ public class BlenderRotateEditor : Editor
 
         Quaternion rotationDelta = Quaternion.AngleAxis(Angle, ObjectAxis);
         // Apply rotation to the object
-        ((Transform)target).localRotation = rotationDelta * Quaternion.Euler(initialRotation);
+        ((Transform)target).rotation = rotationDelta * Quaternion.Euler(initialRotation);
     }
     bool RotateByAngle()
     {


### PR DESCRIPTION
# Local/global rotation/translation
When rotating/translating objects, the current space setting `Global`/`Local` is now considered.
![Local Global Toggle](https://github.com/user-attachments/assets/c5200118-530f-4290-bdc4-c977ea5d1e77)

# Stop action with escape
In addition to `right-clicking` `escape` will also stop the current action and revert it (like in Blender).

# Consume events
`Event.Use()` is used to consume the events when canceling/reverting to prevent the right-click menu from showing up and to prevent selecting something.