### PR TITLE
Small fixes and improve transformation by unit

### DIFF
--- a/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
@@ -1,6 +1,7 @@
 
 // using System;
 // using System.Reflection;
+using System.Globalization;
 using UnityEngine;
 
 public static class BlenderHelper
@@ -127,30 +128,49 @@ public static class BlenderHelper
         }
         return KeyCode.None;
     }
-    public static void AppendUnitNumber(Event e, ref string UnitNumber)
+    public static void AppendUnitNumber(Event e, ref string unitNumber, ref bool isPositive)
     {
-        char input = e.character;
-        if (e.isKey && char.IsDigit(input) || input == '-')
+        if (!(e.type == EventType.KeyDown && e.isKey))
         {
-            if (UnitNumber == "")
+            return;
+        }
+
+        char input = e.character;
+        if (input == '-')
+        {
+            isPositive = !isPositive;
+        }
+        else if (char.IsDigit(input))
+        {
+            unitNumber += input;
+        }
+        else if (input == '.')
+        {
+            if (!unitNumber.Contains('.'))
             {
-                // If the input string is empty, prepend the character with a sign
-                UnitNumber = '+' + input.ToString();
-            }
-            else if (input == '+' || input == '-')
-            {
-                // If a new sign is entered, get the previous sign and multiply it with the new sign
-                int previousSign = UnitNumber[0] == '-' ? -1 : 1;
-                int newSign = input == '-' ? -1 : 1;
-                int resultSign = previousSign * newSign;
-                // Replace the existing sign with the result
-                UnitNumber = (resultSign == 1 ? "+" : "-") + UnitNumber.Substring(1);
-            }
-            else
-            {
-                // Otherwise, append the character
-                UnitNumber += input;
+                unitNumber += input;
             }
         }
+        else if (e.keyCode == KeyCode.Backspace)
+        {
+            if (unitNumber.Length != 0)
+            {
+                unitNumber = unitNumber.Substring(0, unitNumber.Length-1);
+            }
+        }
+    }
+
+    public static bool TryParseUnitNumber(string unitNumber, bool isPositive, out float parsedNumber)
+    {
+        // The CultureInfo must be specified to ensure that '.' is being used as the decimal point.
+        if (float.TryParse(unitNumber, NumberStyles.Float, new CultureInfo("en-US"), out parsedNumber))
+        {
+            if (!isPositive)
+            {
+                parsedNumber = - parsedNumber;
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
@@ -173,4 +173,8 @@ public static class BlenderHelper
         }
         return false;
     }
+    
+    public static bool IsModifierPressed(Event e) {
+        return e.control || e.alt || e.shift;
+    }
 }

--- a/Assets/UnityBlenderControl/Editor/BlenderMoveEditor.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderMoveEditor.cs
@@ -18,6 +18,7 @@ public class BlenderMoveEditor : Editor
 
         if (e.type == EventType.KeyDown
         && e.keyCode == KeyCode.G
+        && !BlenderHelper.IsModifierPressed(e)
         && CurrentTransformMode != TransformMode.Move
         && !BlenderHelper.RightMouseHeld)
         {
@@ -35,6 +36,7 @@ public class BlenderMoveEditor : Editor
 
             ObjectAxis = Vector3.zero;
             moveNumber = "";
+            moveNumberIsPositive = true;
         }
 
 

--- a/Assets/UnityBlenderControl/Editor/BlenderMoveEditor.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderMoveEditor.cs
@@ -9,6 +9,7 @@ public class BlenderMoveEditor : Editor
 
     Vector3 initialOffset;
     private string moveNumber = "";
+    private bool moveNumberIsPositive = true;
     private Vector3 initialMouse;
     public void ObjectMove()
     {
@@ -40,7 +41,7 @@ public class BlenderMoveEditor : Editor
         if (CurrentTransformMode == TransformMode.Move)
         {
 
-            BlenderHelper.AppendUnitNumber(e, ref moveNumber);
+            BlenderHelper.AppendUnitNumber(e, ref moveNumber, ref moveNumberIsPositive);
 
             KeyCode AxisCode = BlenderHelper.AxisKeycode(e);
             if (AxisCode != KeyCode.None)
@@ -95,7 +96,7 @@ public class BlenderMoveEditor : Editor
     bool MoveByUnit(Transform target)
     {
         // Parse the move unit string
-        if (float.TryParse(moveNumber, out float MoveUnit))
+        if (BlenderHelper.TryParseUnitNumber(moveNumber, moveNumberIsPositive, out float MoveUnit))
         {
             Vector3 pos = MoveUnit * (ObjectAxis == Vector3.zero ? target.right : ObjectAxis);
             // move based on the unit input

--- a/Assets/UnityBlenderControl/Editor/BlenderRotateEditor.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotateEditor.cs
@@ -15,6 +15,7 @@ public class BlenderRotateEditor : Editor
 
         if (e.type == EventType.KeyDown
         && e.keyCode == KeyCode.R
+        && !BlenderHelper.IsModifierPressed(e)
         && CurrentTransformMode != TransformMode.Rotate
         && !BlenderHelper.RightMouseHeld)
         {
@@ -28,6 +29,7 @@ public class BlenderRotateEditor : Editor
 
             ObjectAxis = Vector3.one;
             RotationNumber = "";
+            rotationNumberIsPositive = true;
         }
 
 
@@ -104,7 +106,7 @@ public class BlenderRotateEditor : Editor
         {
             // Rotate based on the angle input
             Quaternion rotationDelta = Quaternion.AngleAxis(angle, ObjectAxis);
-            ((Transform)target).localRotation = rotationDelta * Quaternion.Euler(initialRotation);
+            ((Transform)target).rotation = rotationDelta * Quaternion.Euler(initialRotation);
             return true;
         }
         return false;

--- a/Assets/UnityBlenderControl/Editor/BlenderRotateEditor.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotateEditor.cs
@@ -8,6 +8,7 @@ public class BlenderRotateEditor : Editor
     private Vector3 selectedAxis;
     private Vector2 mouseStartPosition;
     private string RotationNumber = "";
+    private bool rotationNumberIsPositive = true;
     public void ObjectRotate()
     {
         Event e = Event.current;
@@ -33,7 +34,7 @@ public class BlenderRotateEditor : Editor
         if (CurrentTransformMode == TransformMode.Rotate)
         {
 
-            BlenderHelper.AppendUnitNumber(e, ref RotationNumber);
+            BlenderHelper.AppendUnitNumber(e, ref RotationNumber, ref rotationNumberIsPositive);
 
             KeyCode AxisCode = BlenderHelper.AxisKeycode(e);
             if (AxisCode != KeyCode.None)
@@ -99,7 +100,7 @@ public class BlenderRotateEditor : Editor
     bool RotateByAngle()
     {
         // Parse the rotation angle string
-        if (float.TryParse(RotationNumber, out float angle))
+        if (BlenderHelper.TryParseUnitNumber(RotationNumber, rotationNumberIsPositive, out float angle))
         {
             // Rotate based on the angle input
             Quaternion rotationDelta = Quaternion.AngleAxis(angle, ObjectAxis);

--- a/Assets/UnityBlenderControl/Editor/BlenderScaleEditor.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderScaleEditor.cs
@@ -15,6 +15,7 @@ public class BlenderScaleEditor : Editor
 
         if (e.type == EventType.KeyDown
         && e.keyCode == KeyCode.S
+        && !BlenderHelper.IsModifierPressed(e)
         && CurrentTransformMode != TransformMode.Scale
         && !BlenderHelper.RightMouseHeld)
         {
@@ -28,6 +29,7 @@ public class BlenderScaleEditor : Editor
 
             ObjectAxis = Vector3.zero;
             ScaleNumber = "";
+            scaleNumberIsPositive = true;
         }
 
 

--- a/Assets/UnityBlenderControl/Editor/BlenderScaleEditor.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderScaleEditor.cs
@@ -8,6 +8,7 @@ public class BlenderScaleEditor : Editor
     private Vector3 selectedAxis;
     private Vector2 mouseStartPosition;
     private string ScaleNumber = "";
+    private bool scaleNumberIsPositive = true;
     public void ObjectScale()
     {
         Event e = Event.current;
@@ -33,7 +34,7 @@ public class BlenderScaleEditor : Editor
         if (CurrentTransformMode == TransformMode.Scale)
         {
 
-            BlenderHelper.AppendUnitNumber(e, ref ScaleNumber);
+            BlenderHelper.AppendUnitNumber(e, ref ScaleNumber, ref scaleNumberIsPositive);
 
             KeyCode AxisCode = BlenderHelper.AxisKeycode(e);
             if (AxisCode != KeyCode.None)
@@ -79,7 +80,7 @@ public class BlenderScaleEditor : Editor
     bool ScaleByUnit()
     {
         // Parse the move unit string
-        if (float.TryParse(ScaleNumber, out float scaleUnit))
+        if (BlenderHelper.TryParseUnitNumber(ScaleNumber, scaleNumberIsPositive, out float scaleUnit))
         {
             Vector3 scale = ModifyScaleVector(scaleUnit, selectedAxis);
             ((Transform)target).localScale = Vector3.Scale(scale, initialScale);


### PR DESCRIPTION
## Fixes
- forgot to adjust `BlenderRotateEditor.RotateByAngle()` in last PR
- don't start transformation when a modifier is pressed in addition to `S`/`G`/`R`
(this prevents for example scaling when pressing `ctrl+s` to save)

## Transformation by unit
- fix: pressing `S`/`G`/`R` followed by `-` would raise an exception
- allow the use of floating point numbers with `.` as the decimal point
- allow backspace to delete the last input character