### PR TITLE
change direction of rotation

### DIFF
--- a/Assets/UnityBlenderControl/Editor/BlenderRotateEditor.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotateEditor.cs
@@ -84,7 +84,7 @@ public class BlenderRotateEditor : Editor
         float initialAngle = AngleBetweenVector2(objectCenter, mouseStartPosition);
 
         // Calculate the current angle between the object center and the current mouse position
-        float currentAngle = AngleBetweenVector2(objectCenter, e.mousePosition);
+        float currentAngle = -AngleBetweenVector2(objectCenter, e.mousePosition);
 
         // Calculate the rotation angle based on the difference between initial and current angles
         float rotationAngle = currentAngle - initialAngle;


### PR DESCRIPTION
Hi, when rotating with mouse it seems that the direction of rotation goes the opposite way of where your mouse goes which I found unintuitive. Reversing it also makes it work more like blender. I found it's a matter of placing a strategic '-' sign.

This modification was made mainly since I find it more convenient, but thought I might share with others who might have a similar issue while I'm at it :).