### PR TITLE
Add option to swap Y and Z axis and make settings autosave

### DIFF
--- a/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
@@ -53,23 +53,21 @@ public static class BlenderHelper
         }
     }
  
-    public static Vector3 GetAxisVector(KeyCode keyCode)
-    {
-        if (keyCode == KeyCode.X)
-        {
-            return Vector3.right;
-        }
-        else if (keyCode == KeyCode.Y)
-        {
-            return Vector3.up;
-        }
-        else if (keyCode == KeyCode.Z)
-        {
-            return Vector3.forward;
-        }
-        else
-        {
-            return Vector3.one;
+    public static Vector3 GetAxisVector(KeyCode keyCode) {
+        if (TransformModeManager.swapYAndZ) {
+            return keyCode switch {
+                KeyCode.X => Vector3.right,
+                KeyCode.Y => Vector3.forward,
+                KeyCode.Z => Vector3.up,
+                _ => Vector3.one
+            }; 
+        } else {
+            return keyCode switch {
+                KeyCode.X => Vector3.right,
+                KeyCode.Y => Vector3.up,
+                KeyCode.Z => Vector3.forward,
+                _ => Vector3.one
+            };
         }
     }
     public static bool RightMouseHeld = false;

--- a/Assets/UnityBlenderControl/Editor/PluginControlWindow.cs
+++ b/Assets/UnityBlenderControl/Editor/PluginControlWindow.cs
@@ -1,10 +1,9 @@
 using UnityEditor;
 using UnityEngine;
 using static TransformModeManager;
+
 public class PluginControlWindow : EditorWindow
 {
-
-
     [MenuItem("Blender/Blender Control Window")]
     public static void ShowWindow()
     {
@@ -13,34 +12,20 @@ public class PluginControlWindow : EditorWindow
     private void OnEnable()
     {
         // Load the saved setting when the window is enabled
-        isBlenderPluginEnabled = EditorPrefs.GetBool("IsPluginEnabled", true);
+        LoadSettings();
     }
     private void OnGUI()
     {
         GUILayout.Label("Blender Plugin Control", EditorStyles.boldLabel);
+        
+        EditorGUI.BeginChangeCheck();
 
         isBlenderPluginEnabled = EditorGUILayout.Toggle("Enable Plugin", isBlenderPluginEnabled);
+        swapYAndZ = EditorGUILayout.Toggle("Swap Y and Z", swapYAndZ);
 
-        if (GUILayout.Button("Apply"))
-        {
-            ApplySettings();
-        }
-    }
-
-    private void ApplySettings()
-    {
-        // Save the setting
-        EditorPrefs.SetBool("IsPluginEnabled", isBlenderPluginEnabled);
-        // Implement logic to enable or disable your plugin based on the 'isPluginEnabled' variable.
-        if (isBlenderPluginEnabled)
-        {
-            Debug.Log("Plugin Enabled");
-            // Enable your plugin
-        }
-        else
-        {
-            Debug.Log("Plugin Disabled");
-            // Disable your plugin
+        if (EditorGUI.EndChangeCheck()) {
+            // save settings if one of them was changed
+            SaveSettings();
         }
     }
 }

--- a/Assets/UnityBlenderControl/Editor/TransformModeManager.cs
+++ b/Assets/UnityBlenderControl/Editor/TransformModeManager.cs
@@ -1,8 +1,27 @@
 using System;
+using UnityEditor;
 using UnityEngine;
 
+[InitializeOnLoad]
 public static class TransformModeManager
 {
+    static TransformModeManager() {
+        // load settings on startup / domain reload
+        LoadSettings()
+    }
+    
+    internal static void LoadSettings() {
+        isBlenderPluginEnabled = EditorPrefs.GetBool("BlenderControlPluginEnabled", true);
+        swapYAndZ = EditorPrefs.GetBool("BlenderControlPluginSwapYAndZ", false);
+        
+    }
+    
+    internal static void SaveSettings()
+    {
+        EditorPrefs.SetBool("BlenderPluginEnabled", isBlenderPluginEnabled);
+        EditorPrefs.SetBool("BlenderPluginSwapYAndZ", swapYAndZ);
+    }
+    
     public enum TransformMode
     {
         None,
@@ -19,5 +38,5 @@ public static class TransformModeManager
     public static Action DrawAxis;
     public static bool isBlenderPluginEnabled = true;
     public static bool isSnappingEnabled = false;
-
+    public static bool swapYAndZ = false;
 }

--- a/Assets/UnityBlenderControl/Editor/VisualEditor.cs
+++ b/Assets/UnityBlenderControl/Editor/VisualEditor.cs
@@ -57,11 +57,11 @@ public class ChangeMouseCursorInEditor
         }
         else if (WorldAxis == Vector3.up)
         {
-            lineColor = Color.green;
+            lineColor = swapYAndZ ? Color.blue : Color.green;
         }
         else if (WorldAxis == Vector3.forward)
         {
-            lineColor = Color.blue;
+            lineColor = swapYAndZ ? Color.green : Color.blue;
         }
         else
         {


### PR DESCRIPTION
Added a setting in the settings menu to swap the Y and Z axies to make them more similar to blender
this changes both the keybinds and line colours when enabled

Also removed the Apply button and made the setting changes autosave as the Apply button does not actually "Apply" the setting changes, it just saves them, and it would be better to not have to click a button at all and just have it apply automatically