### PR TITLE
Small fixes

### DIFF
--- a/Assets/UnityBlenderControl/Editor/BlenderManager.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderManager.cs
@@ -42,7 +42,7 @@ public static class BlenderManager
     public static Vector3 CurrentAxisVector = Vector3.zero;
     public static Color CurrentAxisColor = Color.white;
     private static string CurrentNumberString = "";
-    private static bool CurrentNumberIsPositive = false;
+    private static bool CurrentNumberIsPositive = true;
     public static float CurrentNumber = 0;
     public static bool MoveByNumber => !float.IsNaN(CurrentNumber);
 
@@ -50,7 +50,7 @@ public static class BlenderManager
         CurrentTransformMode = null;
         CurrentAxisVector = Vector3.zero;
         CurrentNumberString = "";
-        CurrentNumberIsPositive = false;
+        CurrentNumberIsPositive = true;
         // reset AxisMode
         LockToAxis = false;
         Tools.pivotRotation = PreviousPivotRotation;

--- a/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
@@ -85,10 +85,11 @@ public class BlenderRotate : BlenderTransformMode
         // change mouse icon
         EditorGUIUtility.AddCursorRect(new Rect(0, 0, Screen.width, Screen.height), MouseCursor.ResizeUpRight);
 
+        float screenScale = Screen.dpi / 96f;
         // draw a black line between the mouse and the pivot point (average object position)
         var mp = Event.current.mousePosition;
         // for some reason the mouse and ScreenToWorldPoint use opposite y axies, so flip that around by doing viewport height - y
-        var mouseWorldPos = sceneView.camera.ScreenToWorldPoint(new Vector3(mp.x, sceneView.cameraViewport.height - mp.y, 1));
+        var mouseWorldPos = sceneView.camera.ScreenToWorldPoint(new Vector3(screenScale * mp.x, screenScale * (sceneView.cameraViewport.height - mp.y), 1));
         Handles.color = Color.black;
         Handles.DrawLine(averagePosition, mouseWorldPos);
         

--- a/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
@@ -133,10 +133,10 @@ public class BlenderRotate : BlenderTransformMode
         float initialAngle = AngleBetweenVector2(center, mouseStartPosition);
 
         // Calculate the current angle between the object center and the current mouse position
-        float currentAngle = -AngleBetweenVector2(center, Event.current.mousePosition);
+        float currentAngle = AngleBetweenVector2(center, Event.current.mousePosition);
 
         // Calculate the rotation angle based on the difference between initial and current angles
-        float rotationAngle = currentAngle - initialAngle;
+        float rotationAngle = initialAngle - currentAngle;
 
         // calculate snap rotation
         float snapRotation = Mathf.Round(rotationAngle / snapValue) * snapValue;

--- a/Assets/UnityBlenderControl/Editor/BlenderScale.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderScale.cs
@@ -84,10 +84,11 @@ public class BlenderScale : BlenderTransformMode
         EditorGUIUtility.AddCursorRect(new Rect(0, 0, Screen.width, Screen.height), MouseCursor.ResizeUpRight);
 
 
+        float screenScale = Screen.dpi / 96f;
         // draw a black line between the mouse and the pivot point (average object position)
         var mp = Event.current.mousePosition;
         // for some reason the mouse and ScreenToWorldPoint use opposite y axies, so flip that around by doing viewport height - y
-        var mouseWorldPos = sceneView.camera.ScreenToWorldPoint(new Vector3(mp.x, sceneView.cameraViewport.height - mp.y, 1));
+        var mouseWorldPos = sceneView.camera.ScreenToWorldPoint(new Vector3(screenScale * mp.x, screenScale * (sceneView.cameraViewport.height - mp.y), 1));
         Handles.color = Color.black;
         Handles.DrawLine(averagePosition, mouseWorldPos);
 

--- a/Assets/UnityBlenderControl/Editor/BlenderScale.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderScale.cs
@@ -121,14 +121,17 @@ public class BlenderScale : BlenderTransformMode
         float snapValue = BlenderHelper.GetSnapScale();
         // Calculate the center of the object in screen space
         var center = HandleUtility.WorldToGUIPoint(averagePosition);
-        // Calculate the initial distance between the object center and the initial mouse position
-        float initialLineLength = Vector2.Distance(center, mouseStartPosition);
 
-        // Calculate the current distance between the object center and the current mouse position
-        float currentLineLength = Vector2.Distance(center, Event.current.mousePosition);
+        Vector3 centerToStartMouse = mouseStartPosition - center;
+        Vector3 centerToCurrentMouse = Event.current.mousePosition - center;
 
         // Calculate the scale factor based on the ratio of initial and current line lengths
+        float initialLineLength = centerToStartMouse.magnitude;
+        float currentLineLength = centerToCurrentMouse.magnitude;
         float scaleFactor = currentLineLength / initialLineLength;
+        if (Vector3.Dot(centerToStartMouse, centerToCurrentMouse) < 0f) {
+            scaleFactor = -scaleFactor;
+        }
         // calculate snap scale
         float SnapScale = Mathf.Round(scaleFactor / snapValue) * snapValue;
         SnapScale = SnapScale == 0 ? 1f : SnapScale;


### PR DESCRIPTION
Hello,
I have fixed some small issues:
- when using display scaling on Windows (e.g. 150%) the line connecting the center and the cursor wasn't drawn to the correct location (in scale- and rotate-mode)
- the current default for distances/degrees was negative before
- scaling negatively is now possible when the mouse is moved more than 90 degrees from its original location (like in blender)
- even without moving the mouse, objects were rotated when entering rotate-mode before