### PR TITLE
Invert rotation direction depending on view direction

### DIFF
--- a/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
@@ -140,7 +140,18 @@ public class BlenderRotate : BlenderTransformMode
 
         // calculate snap rotation
         float snapRotation = Mathf.Round(rotationAngle / snapValue) * snapValue;
-        
+
+        // When looking from the opposite direction the rotation needs to be inverted
+        if (SceneView.lastActiveSceneView != null) {
+            Vector3 viewDirection = SceneView.lastActiveSceneView.camera.transform.forward;
+            if ((BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Local
+                && Vector3.Dot(viewDirection, data.LocalAxis) > 0f)
+                || (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Global
+                && Vector3.Dot(viewDirection, BlenderManager.CurrentAxisVector) > 0f)) {
+                rotationAngle = -rotationAngle;
+            }
+        }
+
         // Use a Quaternion to represent the rotation
         float angle = isSnappingEnabled ? snapRotation : rotationAngle;
 


### PR DESCRIPTION
I have noticed that in order for the rotation direction to be intuitive, the direction has to be inverted when looking from the opposite side. Example: When rotating around the x-axis and looking along the positive x-axis the rotation has to be inverted compared to when looking from the other side, along the negative x-axis.
This implementation works for single and multiple objects, however it should be noted that it only matches Blenders rotation for the single objects case. I didn't entirely understand what the rules for the rotation direction are when multiple objects are rotated in Blender at once. 