### PR TITLE
fix consumption of key event

### DIFF
--- a/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
@@ -2,6 +2,7 @@
 // using System;
 // using System.Reflection;
 using System.Globalization;
+using UnityEditor;
 using UnityEngine;
 
 public static class BlenderHelper
@@ -145,15 +146,27 @@ public static class BlenderHelper
         }
         return KeyCode.None;
     }
+
     public static bool IsKeyDown(Event evt, KeyCode key)
     {
-        if (evt.type == EventType.KeyDown && evt.keyCode == key)
-        {
-            evt.Use(); // prevent Unity overlay
-            return true;
-        }
-        return false;
+        return evt.type == EventType.KeyDown && evt.keyCode == key;
     }
+
+    public static bool ShouldTriggerSimple(Event evt, KeyCode keyCode)
+    {
+        var targets = Selection.transforms;
+
+        bool trigger = IsKeyDown(evt, keyCode)
+            && !IsModifierPressed(evt)
+            && !RightMouseHeld
+            && targets.Length > 0;
+
+        if (trigger) {
+            evt.Use();
+        }
+        return trigger;
+    }
+
     public static void AppendUnitNumber(Event e, ref string unitNumber, ref bool isPositive)
     {
         if (!(e.type == EventType.KeyDown && e.isKey))

--- a/Assets/UnityBlenderControl/Editor/BlenderMove.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderMove.cs
@@ -10,17 +10,12 @@ public class BlenderMove : BlenderTransformMode {
         public Vector3 InitialOffset => InitialPosition - InitialMouse;
         public Vector3 LocalAxis;
     }
-    
+
     private List<PerObjectData> perObjectData;
     public Vector3 averagePosition;
 
     public override bool ShouldTrigger(Event evt) {
-        var targets = Selection.transforms;
-
-        return BlenderHelper.IsKeyDown(evt, KeyCode.G)
-               && !BlenderHelper.IsModifierPressed(evt)
-               && !BlenderHelper.RightMouseHeld
-               && targets.Length > 0;
+        return BlenderHelper.ShouldTriggerSimple(evt, KeyCode.G);
     }
 
     public override void Initialize() {

--- a/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
@@ -11,19 +11,14 @@ public class BlenderRotate : BlenderTransformMode
         public Quaternion InitialRotation;
         public Vector3 LocalAxis;
     }
-    
+
     private List<PerObjectData> perObjectData;
-    
+
     private Vector2 mouseStartPosition;
     public Vector3 averagePosition;
 
     public override bool ShouldTrigger(Event evt) {
-        var targets = Selection.transforms;
-        
-        return BlenderHelper.IsKeyDown(evt, KeyCode.R)
-            && !BlenderHelper.IsModifierPressed(evt)
-            && !BlenderHelper.RightMouseHeld
-            && targets.Length > 0;
+        return BlenderHelper.ShouldTriggerSimple(evt, KeyCode.R);
     }
 
     public override void Initialize() {

--- a/Assets/UnityBlenderControl/Editor/BlenderScale.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderScale.cs
@@ -18,12 +18,7 @@ public class BlenderScale : BlenderTransformMode
     public Vector3 averagePosition;
 
     public override bool ShouldTrigger(Event evt) {
-        var targets = Selection.transforms;
-
-        return BlenderHelper.IsKeyDown(evt, KeyCode.S)
-               && !BlenderHelper.IsModifierPressed(evt)
-               && !BlenderHelper.RightMouseHeld
-               && targets.Length > 0;
+        return BlenderHelper.ShouldTriggerSimple(evt, KeyCode.S);
     }
 
     public override void Initialize() {


### PR DESCRIPTION
The change in cfce5e8 results in the key event always being consumed, even when other requirements (like that the modifier keys and the right mouse button are not pressed) are not fulfilled.
Always consuming the event prevents actions like flying backwards with `s` in the flight mode, that is triggered with right click or saving with `ctrl+s`.
Therefore, I changed it to only `Use` the event when all requirements are fulfilled.