### PR TITLE
Feature: Pivot Point, Location Only and minor changes

### DIFF
--- a/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
@@ -1,6 +1,3 @@
-
-// using System;
-// using System.Reflection;
 using System;
 using System.Globalization;
 using UnityEditor;
@@ -55,24 +52,6 @@ public static class BlenderHelper
         }
     }
 
-    public static Color GetAxisColor(KeyCode keyCode) {
-        if (TransformModeManager.swapYAndZ) {
-            return keyCode switch {
-                KeyCode.X => Color.red,
-                KeyCode.Y => Color.blue,
-                KeyCode.Z => Color.green,
-                _ => Color.white
-            };
-        } else {
-            return keyCode switch {
-                KeyCode.X => Color.red,
-                KeyCode.Y => Color.green,
-                KeyCode.Z => Color.blue,
-                _ => Color.white
-            };
-        }
-    }
-
     public static bool RightMouseHeld = false;
     public static void RightMouseHeldCheck()
     {
@@ -121,15 +100,6 @@ public static class BlenderHelper
         return revert;
     }
 
-    public static KeyCode AxisKeycode(Event e)
-    {
-        if (e.type == EventType.KeyDown && (e.keyCode == KeyCode.X || e.keyCode == KeyCode.Y || e.keyCode == KeyCode.Z)) {
-            e.Use();
-            return e.keyCode;
-        }
-        return KeyCode.None;
-    }
-
     public static bool IsKeyDown(Event evt, KeyCode key)
     {
         return evt.type == EventType.KeyDown && evt.keyCode == key;
@@ -144,7 +114,8 @@ public static class BlenderHelper
             && !RightMouseHeld
             && targets.Length > 0;
 
-        if (trigger) {
+        if (trigger)
+        {
             evt.Use();
         }
         return trigger;
@@ -180,7 +151,8 @@ public static class BlenderHelper
                 unitNumber = unitNumber.Substring(0, unitNumber.Length-1);
             }
         }
-        else {
+        else
+        {
             return;
         }
         e.Use();
@@ -200,12 +172,15 @@ public static class BlenderHelper
         return false;
     }
 
-    public static bool IsModifierPressed(Event e) {
+    public static bool IsModifierPressed(Event e)
+    {
         return e.control || e.alt || e.shift;
     }
 
-    public static Vector3 GetTransformationCenter(Vector3 averagePosition, Bounds bounds) {
-        return BlenderManager.CurrentPivotPoint switch {
+    public static Vector3 GetTransformationCenter(Vector3 averagePosition, Bounds bounds)
+    {
+        return BlenderManager.CurrentPivotPoint switch
+        {
             BlenderManager.PivotPoint.ActiveElement => Selection.activeGameObject.transform.position,
             BlenderManager.PivotPoint.MedianPoint => averagePosition,
             BlenderManager.PivotPoint.BoundingBoxCenter => bounds.center,

--- a/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
@@ -55,24 +55,6 @@ public static class BlenderHelper
         }
     }
 
-    public static Vector3 GetAxisVector(KeyCode keyCode) {
-        if (TransformModeManager.swapYAndZ) {
-            return keyCode switch {
-                KeyCode.X => Vector3.right,
-                KeyCode.Y => Vector3.forward,
-                KeyCode.Z => Vector3.up,
-                _ => Vector3.one
-            };
-        } else {
-            return keyCode switch {
-                KeyCode.X => Vector3.right,
-                KeyCode.Y => Vector3.up,
-                KeyCode.Z => Vector3.forward,
-                _ => Vector3.one
-            };
-        }
-    }
-
     public static Color GetAxisColor(KeyCode keyCode) {
         if (TransformModeManager.swapYAndZ) {
             return keyCode switch {

--- a/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
@@ -1,6 +1,7 @@
 
 // using System;
 // using System.Reflection;
+using System;
 using System.Globalization;
 using UnityEditor;
 using UnityEngine;
@@ -197,6 +198,10 @@ public static class BlenderHelper
                 unitNumber = unitNumber.Substring(0, unitNumber.Length-1);
             }
         }
+        else {
+            return;
+        }
+        e.Use();
     }
 
     public static bool TryParseUnitNumber(string unitNumber, bool isPositive, out float parsedNumber)
@@ -223,7 +228,7 @@ public static class BlenderHelper
             BlenderManager.PivotPoint.MedianPoint => averagePosition,
             BlenderManager.PivotPoint.BoundingBoxCenter => bounds.center,
             BlenderManager.PivotPoint.IndividualOrigins => averagePosition,
-            _ => Vector3.negativeInfinity // Not possible
+            _ => throw new ArgumentOutOfRangeException(nameof(BlenderManager.PivotPoint))
         };
     }
 }

--- a/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderHelper.cs
@@ -53,7 +53,7 @@ public static class BlenderHelper
             return Vector3.zero;
         }
     }
- 
+
     public static Vector3 GetAxisVector(KeyCode keyCode) {
         if (TransformModeManager.swapYAndZ) {
             return keyCode switch {
@@ -61,7 +61,7 @@ public static class BlenderHelper
                 KeyCode.Y => Vector3.forward,
                 KeyCode.Z => Vector3.up,
                 _ => Vector3.one
-            }; 
+            };
         } else {
             return keyCode switch {
                 KeyCode.X => Vector3.right,
@@ -79,7 +79,7 @@ public static class BlenderHelper
                 KeyCode.Y => Color.blue,
                 KeyCode.Z => Color.green,
                 _ => Color.white
-            }; 
+            };
         } else {
             return keyCode switch {
                 KeyCode.X => Color.red,
@@ -89,7 +89,7 @@ public static class BlenderHelper
             };
         }
     }
-    
+
     public static bool RightMouseHeld = false;
     public static void RightMouseHeldCheck()
     {
@@ -121,7 +121,7 @@ public static class BlenderHelper
     {
         bool cancel = e.type == EventType.KeyDown && (e.keyCode == KeyCode.Return || e.keyCode == KeyCode.KeypadEnter)
             || (e.type == EventType.MouseDown && e.button == 0);
-        if (cancel) 
+        if (cancel)
         {
             e.Use();
         }
@@ -131,7 +131,7 @@ public static class BlenderHelper
     {
         bool revert = (e.type == EventType.KeyDown && e.keyCode == KeyCode.Escape)
             || (e.type == EventType.MouseDown && e.button == 1);
-        if (revert) 
+        if (revert)
         {
             e.Use();
         }
@@ -212,8 +212,18 @@ public static class BlenderHelper
         }
         return false;
     }
-    
+
     public static bool IsModifierPressed(Event e) {
         return e.control || e.alt || e.shift;
+    }
+
+    public static Vector3 GetTransformationCenter(Vector3 averagePosition, Bounds bounds) {
+        return BlenderManager.CurrentPivotPoint switch {
+            BlenderManager.PivotPoint.ActiveElement => Selection.activeGameObject.transform.position,
+            BlenderManager.PivotPoint.MedianPoint => averagePosition,
+            BlenderManager.PivotPoint.BoundingBoxCenter => bounds.center,
+            BlenderManager.PivotPoint.IndividualOrigins => averagePosition,
+            _ => Vector3.negativeInfinity // Not possible
+        };
     }
 }

--- a/Assets/UnityBlenderControl/Editor/BlenderManager.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderManager.cs
@@ -19,6 +19,13 @@ public static class BlenderManager {
         MedianPoint,
     }
 
+    public enum Axis {
+        None,
+        X,
+        Y,
+        Z,
+    }
+
     static BlenderManager() {
         // Create an instance of BlenderMove when the BlenderManager is enabled
         TransformModes = new List<BlenderTransformMode> { new BlenderMove(), new BlenderRotate(), new BlenderScale() };
@@ -34,6 +41,7 @@ public static class BlenderManager {
     private static bool LockToAxis = false;
     private static PivotRotation PreviousPivotRotation = PivotRotation.Global;
     public static PivotPoint CurrentPivotPoint = PivotPoint.MedianPoint;
+    public static Axis CurrentAxis = Axis.None;
 
     public static AxisMode CurrentAxisMode {
         get {
@@ -44,8 +52,16 @@ public static class BlenderManager {
             }
         }
     }
-    public static Vector3 CurrentAxisVector = Vector3.zero;
-    public static Color CurrentAxisColor = Color.white;
+    public static Vector3 CurrentAxisVector {
+        get {
+            return CurrentAxis switch {
+                Axis.X => Vector3.right,
+                Axis.Y => Vector3.up,
+                Axis.Z => Vector3.forward,
+                _ => Vector3.one
+            };
+        }
+    }
     private static string CurrentNumberString = "";
     private static bool CurrentNumberIsPositive = true;
     public static float CurrentNumber = 0;
@@ -53,12 +69,44 @@ public static class BlenderManager {
 
     private static void Reset() {
         CurrentTransformMode = null;
-        CurrentAxisVector = Vector3.zero;
+        CurrentAxis = Axis.None;
         CurrentNumberString = "";
         CurrentNumberIsPositive = true;
-        // reset AxisMode
+        ResetAxisLockMode();
+    }
+
+    static void AdvanceAxisLockMode() {
+        // change axis mode Unlocked -> Global -> Local -> Unlocked
+        if (!LockToAxis) {
+            LockToAxis = true;
+        }
+        else {
+            if (Tools.pivotRotation == PreviousPivotRotation) {
+                // switch pivot rotation
+                Tools.pivotRotation = Tools.pivotRotation == PivotRotation.Global ? PivotRotation.Local : PivotRotation.Global;
+            }
+            else {
+                // revert to unlocked
+                LockToAxis = false;
+                Tools.pivotRotation = PreviousPivotRotation;
+            }
+        }
+    }
+
+    static void ResetAxisLockMode() {
         LockToAxis = false;
         Tools.pivotRotation = PreviousPivotRotation;
+    }
+
+    static Color GetAxisColor(bool active) {
+        // The active axis is slightly brighter (controlled with c)
+        float c = active ? 0.6f : 0f;
+        return CurrentAxis switch {
+            Axis.X => new Color(1f, c, c),
+            Axis.Y => new Color(c, 1f, c),
+            Axis.Z => new Color(c, c, 1f),
+            _ => Color.white
+        };
     }
 
     private static void OnDuringSceneGUI(SceneView sv) {
@@ -82,32 +130,25 @@ public static class BlenderManager {
             return;
         }
 
-        var axisCode = BlenderHelper.AxisKeycode(Event.current);
-        if (axisCode != KeyCode.None) {
-            var newAxisVector = BlenderHelper.GetAxisVector(axisCode);
-            if (newAxisVector == CurrentAxisVector) {
-                // change axis mode Unlocked -> Global -> Local -> Unlocked
-                if (!LockToAxis) {
-                    LockToAxis = true;
-                } else {
-                    if (Tools.pivotRotation == PreviousPivotRotation) {
-                        // switch pivot rotation
-                        Tools.pivotRotation = Tools.pivotRotation == PivotRotation.Global ? PivotRotation.Local : PivotRotation.Global;
-                    } else {
-                        // revert to unlocked
-                        LockToAxis = false;
-                        Tools.pivotRotation = PreviousPivotRotation;
-                    }
+        if (Event.current.type == EventType.KeyDown && !(Event.current.alt || Event.current.control)) {
+            Axis newAxis = Event.current.keyCode switch {
+                KeyCode.X => Axis.X,
+                KeyCode.Y => swapYAndZ ? Axis.Z : Axis.Y,
+                KeyCode.Z => swapYAndZ ? Axis.Y : Axis.Z,
+                _ => Axis.None
+            };
+            // OnlyOtherAxis = Event.current.shift;
+            if (newAxis != Axis.None) {
+                if (CurrentAxis == Axis.None || newAxis == CurrentAxis) {
+                    AdvanceAxisLockMode();
                 }
-
-                CurrentTransformMode.OnAxisModeChange();
-            } else {
-                LockToAxis = true;
-                Tools.pivotRotation = PreviousPivotRotation;
-
-                CurrentAxisColor = BlenderHelper.GetAxisColor(axisCode);
-                CurrentAxisVector = newAxisVector;
+                else {
+                    ResetAxisLockMode();
+                }
+                CurrentAxis = newAxis;
                 CurrentTransformMode.OnAxisChange();
+                Event.current.Use();
+                return;
             }
         }
 
@@ -115,7 +156,8 @@ public static class BlenderManager {
 
         if (BlenderHelper.TryParseUnitNumber(CurrentNumberString, CurrentNumberIsPositive, out var newNumber)) {
             CurrentNumber = newNumber;
-        } else {
+        }
+        else {
             CurrentNumber = float.NaN;
         }
 
@@ -124,7 +166,8 @@ public static class BlenderManager {
         if (BlenderHelper.RevertKeyPressed(Event.current)) {
             CurrentTransformMode.Cancel();
             Reset();
-        } else if (BlenderHelper.ApplyKeyPressed(Event.current)) {
+        }
+        else if (BlenderHelper.ApplyKeyPressed(Event.current)) {
             CurrentTransformMode.Apply();
             Reset();
         }
@@ -143,12 +186,11 @@ public static class BlenderManager {
         };
     }
 
-    public static void DrawAxisLine(Vector3 origin, Vector3 direction)
-    {
+    public static void DrawAxisLine(Vector3 origin, Vector3 direction, bool active) {
         if (direction == Vector3.one || direction == Vector3.zero)
             return;
 
-        Handles.color = CurrentAxisColor;
+        Handles.color = GetAxisColor(active);
         var startPoint = origin - direction * 1000f;
         var endPoint = origin + direction * 1000f;
         Handles.DrawLine(startPoint, endPoint);

--- a/Assets/UnityBlenderControl/Editor/BlenderManager.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderManager.cs
@@ -41,6 +41,7 @@ public static class BlenderManager {
     private static bool LockToAxis = false;
     private static PivotRotation PreviousPivotRotation = PivotRotation.Global;
     public static PivotPoint CurrentPivotPoint = PivotPoint.MedianPoint;
+    public static bool LocationOnly = false;
     public static Axis CurrentAxis = Axis.None;
 
     public static AxisMode CurrentAxisMode {

--- a/Assets/UnityBlenderControl/Editor/BlenderManager.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderManager.cs
@@ -17,10 +17,7 @@ public static class BlenderManager {
         BoundingBoxCenter,
         ActiveElement,
         MedianPoint,
-        // OnlyLocation,
-        ThreeDCursor,
     }
-
 
     static BlenderManager() {
         // Create an instance of BlenderMove when the BlenderManager is enabled
@@ -36,6 +33,7 @@ public static class BlenderManager {
 
     private static bool LockToAxis = false;
     private static PivotRotation PreviousPivotRotation = PivotRotation.Global;
+    public static PivotPoint CurrentPivotPoint = PivotPoint.MedianPoint;
 
     public static AxisMode CurrentAxisMode {
         get {
@@ -52,7 +50,6 @@ public static class BlenderManager {
     private static bool CurrentNumberIsPositive = true;
     public static float CurrentNumber = 0;
     public static bool MoveByNumber => !float.IsNaN(CurrentNumber);
-    public static PivotPoint CurrentPivotPoint = PivotPoint.IndividualOrigins;
 
     private static void Reset() {
         CurrentTransformMode = null;

--- a/Assets/UnityBlenderControl/Editor/BlenderManager.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderManager.cs
@@ -5,24 +5,31 @@ using UnityEngine;
 using static TransformModeManager;
 
 [InitializeOnLoad]
-public static class BlenderManager
-{
-    
+public static class BlenderManager {
     public enum AxisMode {
         Unlocked = 0,
         Global = 1,
         Local = 2
     }
 
-    
+    public enum PivotPoint {
+        IndividualOrigins,
+        BoundingBoxCenter,
+        ActiveElement,
+        MedianPoint,
+        // OnlyLocation,
+        ThreeDCursor,
+    }
+
+
     static BlenderManager() {
         // Create an instance of BlenderMove when the BlenderManager is enabled
         TransformModes = new List<BlenderTransformMode> { new BlenderMove(), new BlenderRotate(), new BlenderScale() };
-        
+
         SceneView.duringSceneGui -= OnDuringSceneGUI;
         SceneView.duringSceneGui += OnDuringSceneGUI;
     }
-    
+
     public static List<BlenderTransformMode> TransformModes;
     public static BlenderTransformMode CurrentTransformMode;
 
@@ -45,6 +52,7 @@ public static class BlenderManager
     private static bool CurrentNumberIsPositive = true;
     public static float CurrentNumber = 0;
     public static bool MoveByNumber => !float.IsNaN(CurrentNumber);
+    public static PivotPoint CurrentPivotPoint = PivotPoint.IndividualOrigins;
 
     private static void Reset() {
         CurrentTransformMode = null;
@@ -62,7 +70,7 @@ public static class BlenderManager
 
         BlenderHelper.RightMouseHeldCheck();
         BlenderHelper.CheckSnap();
-        
+
         foreach (var transformMode in TransformModes) {
             if (transformMode != CurrentTransformMode && transformMode.ShouldTrigger(Event.current)) {
                 CurrentTransformMode?.Cancel();
@@ -76,7 +84,7 @@ public static class BlenderManager
             PreviousPivotRotation = Tools.pivotRotation;
             return;
         }
-        
+
         var axisCode = BlenderHelper.AxisKeycode(Event.current);
         if (axisCode != KeyCode.None) {
             var newAxisVector = BlenderHelper.GetAxisVector(axisCode);
@@ -99,7 +107,7 @@ public static class BlenderManager
             } else {
                 LockToAxis = true;
                 Tools.pivotRotation = PreviousPivotRotation;
-                
+
                 CurrentAxisColor = BlenderHelper.GetAxisColor(axisCode);
                 CurrentAxisVector = newAxisVector;
                 CurrentTransformMode.OnAxisChange();
@@ -107,13 +115,13 @@ public static class BlenderManager
         }
 
         BlenderHelper.AppendUnitNumber(Event.current, ref CurrentNumberString, ref CurrentNumberIsPositive);
-        
+
         if (BlenderHelper.TryParseUnitNumber(CurrentNumberString, CurrentNumberIsPositive, out var newNumber)) {
             CurrentNumber = newNumber;
         } else {
             CurrentNumber = float.NaN;
         }
-            
+
         CurrentTransformMode.Process(sv);
 
         if (BlenderHelper.RevertKeyPressed(Event.current)) {
@@ -137,7 +145,7 @@ public static class BlenderManager
             _ => throw new ArgumentOutOfRangeException()
         };
     }
-    
+
     public static void DrawAxisLine(Vector3 origin, Vector3 direction)
     {
         if (direction == Vector3.one || direction == Vector3.zero)

--- a/Assets/UnityBlenderControl/Editor/BlenderMove.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderMove.cs
@@ -70,15 +70,14 @@ public class BlenderMove : BlenderTransformMode {
     }
 
     public override void DrawSceneGUI(SceneView sceneView) {
+        // TODO eliminate nearly identical code
         switch (BlenderManager.CurrentAxisMode) {
             case BlenderManager.AxisMode.Unlocked:
                 break;
             case BlenderManager.AxisMode.Global:
-                // draw at average position
                 BlenderManager.DrawAxisLine(averagePosition, BlenderManager.CurrentAxisVector);
                 break;
             case BlenderManager.AxisMode.Local:
-                // draw at each object's position
                 foreach (var data in perObjectData) {
                     BlenderManager.DrawAxisLine(data.InitialPosition, data.LocalAxis);
                 }

--- a/Assets/UnityBlenderControl/Editor/BlenderMove.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderMove.cs
@@ -80,7 +80,7 @@ public class BlenderMove : BlenderTransformMode {
             case BlenderManager.AxisMode.Local:
                 // draw at each object's position
                 foreach (var data in perObjectData) {
-                    BlenderManager.DrawAxisLine(data.Transform.position, data.LocalAxis);
+                    BlenderManager.DrawAxisLine(data.InitialPosition, data.LocalAxis);
                 }
                 break;
         }
@@ -107,7 +107,7 @@ public class BlenderMove : BlenderTransformMode {
             _ => Vector3.zero
         };
     }
-    
+
     private void MoveByMouse(PerObjectData data) {
         Vector3 currentMousePosition = GetWorldMouse(data.InitialPosition);
         Vector3 snapValue = BlenderHelper.GetSnapMove();

--- a/Assets/UnityBlenderControl/Editor/BlenderMove.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderMove.cs
@@ -75,11 +75,11 @@ public class BlenderMove : BlenderTransformMode {
             case BlenderManager.AxisMode.Unlocked:
                 break;
             case BlenderManager.AxisMode.Global:
-                BlenderManager.DrawAxisLine(averagePosition, BlenderManager.CurrentAxisVector);
+                BlenderManager.DrawAxisLine(averagePosition, BlenderManager.CurrentAxisVector, true);
                 break;
             case BlenderManager.AxisMode.Local:
                 foreach (var data in perObjectData) {
-                    BlenderManager.DrawAxisLine(data.InitialPosition, data.LocalAxis);
+                    BlenderManager.DrawAxisLine(data.InitialPosition, data.LocalAxis, Selection.activeTransform == data.Transform);
                 }
                 break;
         }

--- a/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
@@ -110,6 +110,7 @@ public class BlenderRotate : BlenderTransformMode {
     }
 
     private void DoRotate(SceneView sv, PerObjectData data, float amount) {
+        // Rotation change
         Quaternion deltaRotation;
         switch (BlenderManager.CurrentAxisMode) {
             case BlenderManager.AxisMode.Local:
@@ -130,9 +131,20 @@ public class BlenderRotate : BlenderTransformMode {
                 break;
         }
 
+        // Position change
         if (BlenderManager.CurrentPivotPoint != BlenderManager.PivotPoint.IndividualOrigins) {
             Vector3 center = BlenderHelper.GetTransformationCenter(averagePosition, bounds);
-            data.Transform.position = center + deltaRotation * (data.InitialPosition - center);
+            Vector3 globalDir = data.InitialPosition - center;
+            Vector3 rotatedGlobalDir;
+            if (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Local) {
+                Vector3 localDir = Quaternion.Inverse(data.InitialRotation) * globalDir;
+                Vector3 rotatedLocalDir = deltaRotation * localDir;
+                rotatedGlobalDir = data.InitialRotation * rotatedLocalDir;
+            }
+            else {
+                rotatedGlobalDir = deltaRotation * globalDir;
+            }
+            data.Transform.position = center + rotatedGlobalDir;
         }
     }
 

--- a/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
@@ -80,9 +80,6 @@ public class BlenderRotate : BlenderTransformMode {
     }
 
     public override void DrawSceneGUI(SceneView sceneView) {
-        // change mouse icon
-        EditorGUIUtility.AddCursorRect(new Rect(0, 0, Screen.width, Screen.height), MouseCursor.ResizeUpRight);
-
         float screenScale = Screen.dpi / 96f;
         // draw a black line between the mouse and the pivot point (average object position)
         var mp = Event.current.mousePosition;
@@ -91,6 +88,17 @@ public class BlenderRotate : BlenderTransformMode {
         Vector3 center = BlenderHelper.GetTransformationCenter(averagePosition, bounds);
         Handles.color = Color.black;
         Handles.DrawLine(center, mouseWorldPos);
+
+        // TODO refactor duplicated code
+        if (BlenderManager.LocationOnly && BlenderManager.CurrentPivotPoint == BlenderManager.PivotPoint.IndividualOrigins) {
+            EditorGUIUtility.AddCursorRect(new Rect(0, 0, Screen.width, Screen.height), MouseCursor.NotAllowed);
+            // Trigger repaint because the line connecting the center and cursor wouldn't be repainted otherwise when only the mouse position changes.
+            SceneView.RepaintAll();
+            return;
+        }
+        else {
+            EditorGUIUtility.AddCursorRect(new Rect(0, 0, Screen.width, Screen.height), MouseCursor.ResizeUpRight);
+        }
 
         // TODO eliminate nearly identical code
         switch (BlenderManager.CurrentAxisMode) {
@@ -108,25 +116,21 @@ public class BlenderRotate : BlenderTransformMode {
     }
 
     private void DoRotate(SceneView sv, PerObjectData data, float amount) {
+        Quaternion deltaRotation = BlenderManager.CurrentAxisMode switch {
+            BlenderManager.AxisMode.Local => Quaternion.AngleAxis(amount, BlenderManager.CurrentAxisVector),
+            BlenderManager.AxisMode.Global => Quaternion.AngleAxis(amount, BlenderManager.CurrentAxisVector),
+            BlenderManager.AxisMode.Unlocked => Quaternion.AngleAxis(amount, -sv.camera.transform.forward),
+            _ => Quaternion.identity
+        };
+
         // Rotation change
-        Quaternion deltaRotation;
-        switch (BlenderManager.CurrentAxisMode) {
-            case BlenderManager.AxisMode.Local:
-                deltaRotation = Quaternion.AngleAxis(amount, BlenderManager.CurrentAxisVector);
+        if (!BlenderManager.LocationOnly) {
+            if (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Local) {
                 data.Transform.rotation = data.InitialRotation * deltaRotation;
-                break;
-            case BlenderManager.AxisMode.Global:
-                deltaRotation = Quaternion.AngleAxis(amount, BlenderManager.CurrentAxisVector);
+            }
+            else {
                 data.Transform.rotation = deltaRotation * data.InitialRotation;
-                break;
-            case BlenderManager.AxisMode.Unlocked:
-                deltaRotation = Quaternion.AngleAxis(amount, -sv.camera.transform.forward);
-                data.Transform.rotation = deltaRotation * data.InitialRotation;
-                break;
-            default:
-                deltaRotation = Quaternion.identity;
-                data.Transform.rotation = data.InitialRotation;
-                break;
+            }
         }
 
         // Position change
@@ -146,8 +150,7 @@ public class BlenderRotate : BlenderTransformMode {
         }
     }
 
-    void RotateByMouse(SceneView sv, PerObjectData data)
-    {
+    void RotateByMouse(SceneView sv, PerObjectData data) {
         float snapValue = BlenderHelper.GetSnapRotate();
         // Calculate the center of the object in screen space
         //Vector3 objectCenter = HandleUtility.WorldToGUIPoint(data.Transform.position);

--- a/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
@@ -15,6 +15,7 @@ public class BlenderRotate : BlenderTransformMode {
 
     private Vector2 mouseStartPosition;
     public Vector3 averagePosition;
+    Bounds bounds;
 
     public override bool ShouldTrigger(Event evt) {
         return BlenderHelper.ShouldTriggerSimple(evt, KeyCode.R);
@@ -26,6 +27,7 @@ public class BlenderRotate : BlenderTransformMode {
         perObjectData = new List<PerObjectData>();
         mouseStartPosition = Event.current.mousePosition;
         averagePosition = Vector3.zero;
+        bounds.SetMinMax(Vector3.positiveInfinity, Vector3.negativeInfinity);
         foreach (var transform in transforms) {
             perObjectData.Add(new PerObjectData {
                 Transform = transform,
@@ -33,7 +35,10 @@ public class BlenderRotate : BlenderTransformMode {
                 InitialRotation = transform.rotation,
                 LocalAxis = BlenderHelper.GetObjectAxis(transform, BlenderManager.CurrentAxisVector)
             });
+
             averagePosition += transform.position;
+
+            bounds.Encapsulate(transform.position);
         }
         averagePosition /= transforms.Length;
     }
@@ -83,8 +88,9 @@ public class BlenderRotate : BlenderTransformMode {
         var mp = Event.current.mousePosition;
         // for some reason the mouse and ScreenToWorldPoint use opposite y axies, so flip that around by doing viewport height - y
         var mouseWorldPos = sceneView.camera.ScreenToWorldPoint(new Vector3(screenScale * mp.x, screenScale * (sceneView.cameraViewport.height - mp.y), 1));
+        Vector3 center = BlenderHelper.GetTransformationCenter(averagePosition, bounds);
         Handles.color = Color.black;
-        Handles.DrawLine(averagePosition, mouseWorldPos);
+        Handles.DrawLine(center, mouseWorldPos);
 
         // TODO eliminate duplicated code
         switch (BlenderManager.CurrentAxisMode) {
@@ -92,7 +98,7 @@ public class BlenderRotate : BlenderTransformMode {
                 break;
             case BlenderManager.AxisMode.Global:
                 // draw at average position
-                BlenderManager.DrawAxisLine(averagePosition, BlenderManager.CurrentAxisVector);
+                BlenderManager.DrawAxisLine(center, BlenderManager.CurrentAxisVector);
                 break;
             case BlenderManager.AxisMode.Local:
                 // draw at each object's position
@@ -124,8 +130,9 @@ public class BlenderRotate : BlenderTransformMode {
                 break;
         }
 
-        if (BlenderManager.CurrentPivotPoint == BlenderManager.PivotPoint.MedianPoint) {
-            data.Transform.position = averagePosition + deltaRotation * (data.InitialPosition - averagePosition);
+        if (BlenderManager.CurrentPivotPoint != BlenderManager.PivotPoint.IndividualOrigins) {
+            Vector3 center = BlenderHelper.GetTransformationCenter(averagePosition, bounds);
+            data.Transform.position = center + deltaRotation * (data.InitialPosition - center);
         }
     }
 
@@ -134,7 +141,7 @@ public class BlenderRotate : BlenderTransformMode {
         float snapValue = BlenderHelper.GetSnapRotate();
         // Calculate the center of the object in screen space
         //Vector3 objectCenter = HandleUtility.WorldToGUIPoint(data.Transform.position);
-        Vector3 center = HandleUtility.WorldToGUIPoint(averagePosition);
+        Vector3 center = HandleUtility.WorldToGUIPoint(BlenderHelper.GetTransformationCenter(averagePosition, bounds));
         // Calculate the initial angle between the object center and the initial mouse position
         float initialAngle = AngleBetweenVector2(center, mouseStartPosition);
 

--- a/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
@@ -92,16 +92,14 @@ public class BlenderRotate : BlenderTransformMode {
         Handles.color = Color.black;
         Handles.DrawLine(center, mouseWorldPos);
 
-        // TODO eliminate duplicated code
+        // TODO eliminate nearly identical code
         switch (BlenderManager.CurrentAxisMode) {
             case BlenderManager.AxisMode.Unlocked:
                 break;
             case BlenderManager.AxisMode.Global:
-                // draw at average position
                 BlenderManager.DrawAxisLine(center, BlenderManager.CurrentAxisVector);
                 break;
             case BlenderManager.AxisMode.Local:
-                // draw at each object's position
                 foreach (var data in perObjectData) {
                     BlenderManager.DrawAxisLine(data.InitialPosition, data.LocalAxis);
                 }

--- a/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
@@ -97,11 +97,11 @@ public class BlenderRotate : BlenderTransformMode {
             case BlenderManager.AxisMode.Unlocked:
                 break;
             case BlenderManager.AxisMode.Global:
-                BlenderManager.DrawAxisLine(center, BlenderManager.CurrentAxisVector);
+                BlenderManager.DrawAxisLine(center, BlenderManager.CurrentAxisVector, true);
                 break;
             case BlenderManager.AxisMode.Local:
                 foreach (var data in perObjectData) {
-                    BlenderManager.DrawAxisLine(data.InitialPosition, data.LocalAxis);
+                    BlenderManager.DrawAxisLine(data.InitialPosition, data.LocalAxis, Selection.activeTransform == data.Transform);
                 }
                 break;
         }
@@ -168,7 +168,7 @@ public class BlenderRotate : BlenderTransformMode {
         if (SceneView.lastActiveSceneView != null) {
             Vector3 viewDirection = SceneView.lastActiveSceneView.camera.transform.forward;
             if ((BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Local
-                && Vector3.Dot(viewDirection, data.LocalAxis) > 0f)
+                && Vector3.Dot(viewDirection, Selection.activeTransform.rotation * BlenderManager.CurrentAxisVector) > 0f)
                 || (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Global
                 && Vector3.Dot(viewDirection, BlenderManager.CurrentAxisVector) > 0f)) {
                 rotationAngle = -rotationAngle;

--- a/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
@@ -3,8 +3,7 @@ using UnityEditor;
 using UnityEngine;
 using static TransformModeManager;
 
-public class BlenderRotate : BlenderTransformMode
-{
+public class BlenderRotate : BlenderTransformMode {
     struct PerObjectData {
         public Transform Transform;
         public Vector3 InitialPosition;
@@ -86,34 +85,47 @@ public class BlenderRotate : BlenderTransformMode
         var mouseWorldPos = sceneView.camera.ScreenToWorldPoint(new Vector3(screenScale * mp.x, screenScale * (sceneView.cameraViewport.height - mp.y), 1));
         Handles.color = Color.black;
         Handles.DrawLine(averagePosition, mouseWorldPos);
-        
-        if (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Unlocked) {
-            return;
-        }
-        
-        // draw at each object's position
-        foreach (var data in perObjectData) {
-            var direction = BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Global
-                ? BlenderManager.CurrentAxisVector
-                : data.LocalAxis;
-            BlenderManager.DrawAxisLine(data.Transform.position, direction);
+
+        // TODO eliminate duplicated code
+        switch (BlenderManager.CurrentAxisMode) {
+            case BlenderManager.AxisMode.Unlocked:
+                break;
+            case BlenderManager.AxisMode.Global:
+                // draw at average position
+                BlenderManager.DrawAxisLine(averagePosition, BlenderManager.CurrentAxisVector);
+                break;
+            case BlenderManager.AxisMode.Local:
+                // draw at each object's position
+                foreach (var data in perObjectData) {
+                    BlenderManager.DrawAxisLine(data.InitialPosition, data.LocalAxis);
+                }
+                break;
         }
     }
 
     private void DoRotate(SceneView sv, PerObjectData data, float amount) {
+        Quaternion deltaRotation;
         switch (BlenderManager.CurrentAxisMode) {
             case BlenderManager.AxisMode.Local:
-                data.Transform.rotation = data.InitialRotation * Quaternion.AngleAxis(amount, BlenderManager.CurrentAxisVector);
+                deltaRotation = Quaternion.AngleAxis(amount, BlenderManager.CurrentAxisVector);
+                data.Transform.rotation = data.InitialRotation * deltaRotation;
                 break;
             case BlenderManager.AxisMode.Global:
-                data.Transform.rotation = Quaternion.AngleAxis(amount, BlenderManager.CurrentAxisVector) * data.InitialRotation;
+                deltaRotation = Quaternion.AngleAxis(amount, BlenderManager.CurrentAxisVector);
+                data.Transform.rotation = deltaRotation * data.InitialRotation;
                 break;
             case BlenderManager.AxisMode.Unlocked:
-                data.Transform.rotation = Quaternion.AngleAxis(amount, -sv.camera.transform.forward) * data.InitialRotation;
+                deltaRotation = Quaternion.AngleAxis(amount, -sv.camera.transform.forward);
+                data.Transform.rotation = deltaRotation * data.InitialRotation;
                 break;
             default:
+                deltaRotation = Quaternion.identity;
                 data.Transform.rotation = data.InitialRotation;
                 break;
+        }
+
+        if (BlenderManager.CurrentPivotPoint == BlenderManager.PivotPoint.MedianPoint) {
+            data.Transform.position = averagePosition + deltaRotation * (data.InitialPosition - averagePosition);
         }
     }
 
@@ -151,12 +163,13 @@ public class BlenderRotate : BlenderTransformMode
 
         DoRotate(sv, data, angle);
     }
+
     void RotateByAngle(SceneView sv, PerObjectData data) {
         DoRotate(sv, data, BlenderManager.CurrentNumber);
     }
+
     // Function to calculate the angle between two Vector2 points
-    float AngleBetweenVector2(Vector3 vec1, Vector3 vec2)
-    {
+    float AngleBetweenVector2(Vector3 vec1, Vector3 vec2) {
         Vector3 from = vec2 - vec1;
         Vector3 to = new Vector3(1, 0, 0); // You can change this to your desired reference vector
 

--- a/Assets/UnityBlenderControl/Editor/BlenderScale.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderScale.cs
@@ -3,17 +3,16 @@ using UnityEditor;
 using UnityEngine;
 using static TransformModeManager;
 
-public class BlenderScale : BlenderTransformMode
-{
-        struct PerObjectData {
+public class BlenderScale : BlenderTransformMode {
+    struct PerObjectData {
         public Transform Transform;
         public Vector3 InitialPosition;
         public Vector3 InitialScale;
         public Vector3 LocalAxis;
     }
-    
+
     private List<PerObjectData> perObjectData;
-    
+
     private Vector2 mouseStartPosition;
     public Vector3 averagePosition;
 
@@ -42,6 +41,7 @@ public class BlenderScale : BlenderTransformMode
     public override void Cancel() {
         foreach (var data in perObjectData) {
             data.Transform.localScale = data.InitialScale;
+            data.Transform.position = data.InitialPosition;
         }
         perObjectData = null;
     }
@@ -89,7 +89,7 @@ public class BlenderScale : BlenderTransformMode
         if (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Unlocked) {
             return;
         }
-        
+
         foreach (var data in perObjectData) {
             BlenderManager.DrawAxisLine(data.Transform.position, data.LocalAxis);
         }
@@ -105,13 +105,20 @@ public class BlenderScale : BlenderTransformMode
             axis.z == 0 ? 1f : scaleFactor
         );
     }
-    void ScaleByUnit(PerObjectData data)
-    {
-        Vector3 scale = ModifyScaleVector(BlenderManager.CurrentNumber);
+
+    void DoScale(PerObjectData data, float amount) {
+        Vector3 scale = ModifyScaleVector(amount);
         data.Transform.localScale = Vector3.Scale(scale, data.InitialScale);
+        if (BlenderManager.CurrentPivotPoint == BlenderManager.PivotPoint.MedianPoint) {
+            data.Transform.position = averagePosition + Vector3.Scale(scale, data.InitialPosition - averagePosition);
+        }
     }
-    void ScaleByMouse(PerObjectData data)
-    {
+
+    void ScaleByUnit(PerObjectData data) {
+        DoScale(data, BlenderManager.CurrentNumber);
+    }
+
+    void ScaleByMouse(PerObjectData data) {
         float snapValue = BlenderHelper.GetSnapScale();
         // Calculate the center of the object in screen space
         var center = HandleUtility.WorldToGUIPoint(averagePosition);
@@ -129,10 +136,9 @@ public class BlenderScale : BlenderTransformMode
         // calculate snap scale
         float SnapScale = Mathf.Round(scaleFactor / snapValue) * snapValue;
         SnapScale = SnapScale == 0 ? 1f : SnapScale;
-        
+
         float DesiredScale = isSnappingEnabled ? SnapScale : scaleFactor;
         // Apply scale to the object
-        Vector3 scale = ModifyScaleVector(DesiredScale);
-        data.Transform.localScale = Vector3.Scale(scale, data.InitialScale);
+        DoScale(data, DesiredScale);
     }
 }

--- a/Assets/UnityBlenderControl/Editor/BlenderScale.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderScale.cs
@@ -114,8 +114,10 @@ public class BlenderScale : BlenderTransformMode {
 
     void DoScale(PerObjectData data, float amount) {
         Vector3 scale = ModifyScaleVector(amount);
+        // Scale change
         data.Transform.localScale = Vector3.Scale(scale, data.InitialScale);
 
+        // Postion change
         if (BlenderManager.CurrentPivotPoint != BlenderManager.PivotPoint.IndividualOrigins) {
             Vector3 center = BlenderHelper.GetTransformationCenter(averagePosition, bounds);
             data.Transform.position = center + Vector3.Scale(scale, data.InitialPosition - center);

--- a/Assets/UnityBlenderControl/Editor/BlenderScale.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderScale.cs
@@ -15,6 +15,7 @@ public class BlenderScale : BlenderTransformMode {
 
     private Vector2 mouseStartPosition;
     public Vector3 averagePosition;
+    Bounds bounds;
 
     public override bool ShouldTrigger(Event evt) {
         return BlenderHelper.ShouldTriggerSimple(evt, KeyCode.S);
@@ -26,6 +27,7 @@ public class BlenderScale : BlenderTransformMode {
         perObjectData = new List<PerObjectData>();
         averagePosition = Vector3.zero;
         mouseStartPosition = Event.current.mousePosition;
+        bounds.SetMinMax(Vector3.positiveInfinity, Vector3.negativeInfinity);
         foreach (var transform in transforms) {
             perObjectData.Add(new PerObjectData {
                 Transform = transform,
@@ -33,7 +35,10 @@ public class BlenderScale : BlenderTransformMode {
                 InitialScale = transform.localScale,
                 LocalAxis = BlenderHelper.GetObjectAxis(transform, BlenderManager.CurrentAxisVector)
             });
+
             averagePosition += transform.position;
+
+            bounds.Encapsulate(transform.position);
         }
         averagePosition /= transforms.Length;
     }
@@ -83,8 +88,9 @@ public class BlenderScale : BlenderTransformMode {
         var mp = Event.current.mousePosition;
         // for some reason the mouse and ScreenToWorldPoint use opposite y axies, so flip that around by doing viewport height - y
         var mouseWorldPos = sceneView.camera.ScreenToWorldPoint(new Vector3(screenScale * mp.x, screenScale * (sceneView.cameraViewport.height - mp.y), 1));
+        Vector3 center = BlenderHelper.GetTransformationCenter(averagePosition, bounds);
         Handles.color = Color.black;
-        Handles.DrawLine(averagePosition, mouseWorldPos);
+        Handles.DrawLine(center, mouseWorldPos);
 
         if (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Unlocked) {
             return;
@@ -109,8 +115,10 @@ public class BlenderScale : BlenderTransformMode {
     void DoScale(PerObjectData data, float amount) {
         Vector3 scale = ModifyScaleVector(amount);
         data.Transform.localScale = Vector3.Scale(scale, data.InitialScale);
-        if (BlenderManager.CurrentPivotPoint == BlenderManager.PivotPoint.MedianPoint) {
-            data.Transform.position = averagePosition + Vector3.Scale(scale, data.InitialPosition - averagePosition);
+
+        if (BlenderManager.CurrentPivotPoint != BlenderManager.PivotPoint.IndividualOrigins) {
+            Vector3 center = BlenderHelper.GetTransformationCenter(averagePosition, bounds);
+            data.Transform.position = center + Vector3.Scale(scale, data.InitialPosition - center);
         }
     }
 
@@ -121,7 +129,7 @@ public class BlenderScale : BlenderTransformMode {
     void ScaleByMouse(PerObjectData data) {
         float snapValue = BlenderHelper.GetSnapScale();
         // Calculate the center of the object in screen space
-        var center = HandleUtility.WorldToGUIPoint(averagePosition);
+        var center = HandleUtility.WorldToGUIPoint(BlenderHelper.GetTransformationCenter(averagePosition, bounds));
 
         Vector3 centerToStartMouse = mouseStartPosition - center;
         Vector3 centerToCurrentMouse = Event.current.mousePosition - center;

--- a/Assets/UnityBlenderControl/Editor/BlenderScale.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderScale.cs
@@ -97,11 +97,11 @@ public class BlenderScale : BlenderTransformMode {
             case BlenderManager.AxisMode.Unlocked:
                 break;
             case BlenderManager.AxisMode.Global:
-                BlenderManager.DrawAxisLine(center, BlenderManager.CurrentAxisVector);
+                BlenderManager.DrawAxisLine(center, BlenderManager.CurrentAxisVector, true);
                 break;
             case BlenderManager.AxisMode.Local:
                 foreach (var data in perObjectData) {
-                    BlenderManager.DrawAxisLine(data.InitialPosition, data.LocalAxis);
+                    BlenderManager.DrawAxisLine(data.InitialPosition, data.LocalAxis, Selection.activeTransform == data.Transform);
                 }
                 break;
         }

--- a/Assets/UnityBlenderControl/Editor/BlenderScale.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderScale.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -80,9 +79,6 @@ public class BlenderScale : BlenderTransformMode {
     }
 
     public override void DrawSceneGUI(SceneView sceneView) {
-        // change mouse icon
-        EditorGUIUtility.AddCursorRect(new Rect(0, 0, Screen.width, Screen.height), MouseCursor.ResizeUpRight);
-
         float screenScale = Screen.dpi / 96f;
         // draw a black line between the mouse and the pivot point (average object position)
         var mp = Event.current.mousePosition;
@@ -91,6 +87,17 @@ public class BlenderScale : BlenderTransformMode {
         Vector3 center = BlenderHelper.GetTransformationCenter(averagePosition, bounds);
         Handles.color = Color.black;
         Handles.DrawLine(center, mouseWorldPos);
+
+        // TODO refactor duplicated code
+        if (BlenderManager.LocationOnly && BlenderManager.CurrentPivotPoint == BlenderManager.PivotPoint.IndividualOrigins) {
+            EditorGUIUtility.AddCursorRect(new Rect(0, 0, Screen.width, Screen.height), MouseCursor.NotAllowed);
+            // Trigger repaint because the line connecting the center and cursor wouldn't be repainted otherwise when only the mouse position changes.
+            SceneView.RepaintAll();
+            return;
+        }
+        else {
+            EditorGUIUtility.AddCursorRect(new Rect(0, 0, Screen.width, Screen.height), MouseCursor.ResizeUpRight);
+        }
 
         // TODO eliminate nearly identical code
         switch (BlenderManager.CurrentAxisMode) {
@@ -112,15 +119,19 @@ public class BlenderScale : BlenderTransformMode {
         Vector3 scale;
         if (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Unlocked) {
             scale = amount * Vector3.one;
-            data.Transform.localScale = Vector3.Scale(scale, data.InitialScale);
+            if (!BlenderManager.LocationOnly) {
+                data.Transform.localScale = Vector3.Scale(scale, data.InitialScale);
+            }
         }
         else {
             scale = Vector3.one + BlenderManager.CurrentAxisVector * (amount - 1f);
-            if (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Global) {
-                data.Transform.localScale = Quaternion.Inverse(data.Transform.rotation) * Vector3.Scale(scale, data.Transform.rotation * data.InitialScale);
-            }
-            else { // BlenderManager.AxisMode.Local
-                data.Transform.localScale = Vector3.Scale(scale, data.InitialScale);
+            if (!BlenderManager.LocationOnly) {
+                if (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Global) {
+                    data.Transform.localScale = Quaternion.Inverse(data.Transform.rotation) * Vector3.Scale(scale, data.Transform.rotation * data.InitialScale);
+                }
+                else { // BlenderManager.AxisMode.Local
+                    data.Transform.localScale = Vector3.Scale(scale, data.InitialScale);
+                }
             }
         }
 

--- a/Assets/UnityBlenderControl/Editor/BlenderScale.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderScale.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -82,7 +83,6 @@ public class BlenderScale : BlenderTransformMode {
         // change mouse icon
         EditorGUIUtility.AddCursorRect(new Rect(0, 0, Screen.width, Screen.height), MouseCursor.ResizeUpRight);
 
-
         float screenScale = Screen.dpi / 96f;
         // draw a black line between the mouse and the pivot point (average object position)
         var mp = Event.current.mousePosition;
@@ -92,35 +92,52 @@ public class BlenderScale : BlenderTransformMode {
         Handles.color = Color.black;
         Handles.DrawLine(center, mouseWorldPos);
 
-        if (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Unlocked) {
-            return;
+        // TODO eliminate nearly identical code
+        switch (BlenderManager.CurrentAxisMode) {
+            case BlenderManager.AxisMode.Unlocked:
+                break;
+            case BlenderManager.AxisMode.Global:
+                BlenderManager.DrawAxisLine(center, BlenderManager.CurrentAxisVector);
+                break;
+            case BlenderManager.AxisMode.Local:
+                foreach (var data in perObjectData) {
+                    BlenderManager.DrawAxisLine(data.InitialPosition, data.LocalAxis);
+                }
+                break;
         }
-
-        foreach (var data in perObjectData) {
-            BlenderManager.DrawAxisLine(data.Transform.position, data.LocalAxis);
-        }
-    }
-
-    Vector3 ModifyScaleVector(float scaleFactor) {
-        var axis = BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Unlocked
-            ? Vector3.one
-            : BlenderManager.CurrentAxisVector;
-        return new Vector3(
-            axis.x == 0 ? 1f : scaleFactor,
-            axis.y == 0 ? 1f : scaleFactor,
-            axis.z == 0 ? 1f : scaleFactor
-        );
     }
 
     void DoScale(PerObjectData data, float amount) {
-        Vector3 scale = ModifyScaleVector(amount);
         // Scale change
-        data.Transform.localScale = Vector3.Scale(scale, data.InitialScale);
+        Vector3 scale;
+        if (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Unlocked) {
+            scale = amount * Vector3.one;
+            data.Transform.localScale = Vector3.Scale(scale, data.InitialScale);
+        }
+        else {
+            scale = Vector3.one + BlenderManager.CurrentAxisVector * (amount - 1f);
+            if (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Global) {
+                data.Transform.localScale = Quaternion.Inverse(data.Transform.rotation) * Vector3.Scale(scale, data.Transform.rotation * data.InitialScale);
+            }
+            else { // BlenderManager.AxisMode.Local
+                data.Transform.localScale = Vector3.Scale(scale, data.InitialScale);
+            }
+        }
 
         // Postion change
         if (BlenderManager.CurrentPivotPoint != BlenderManager.PivotPoint.IndividualOrigins) {
             Vector3 center = BlenderHelper.GetTransformationCenter(averagePosition, bounds);
-            data.Transform.position = center + Vector3.Scale(scale, data.InitialPosition - center);
+            if (BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Unlocked) {
+                data.Transform.position = center + (data.InitialPosition - center) * amount;
+            }
+            else {
+                Vector3 projectionAxis = BlenderManager.CurrentAxisMode == BlenderManager.AxisMode.Global
+                    ? BlenderManager.CurrentAxisVector
+                    : data.Transform.rotation * BlenderManager.CurrentAxisVector;
+                float initialDistance = -Vector3.Dot(projectionAxis, center - data.InitialPosition);
+                Vector3 projectedCenter = data.InitialPosition + projectionAxis * -initialDistance;
+                data.Transform.position = projectedCenter + projectionAxis * initialDistance * amount;
+            }
         }
     }
 

--- a/Assets/UnityBlenderControl/Editor/PieMenus.meta
+++ b/Assets/UnityBlenderControl/Editor/PieMenus.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f25ee4683a1534344ab0d14fb524d08f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UnityBlenderControl/Editor/PieMenus/DrawModePieMenu.cs
+++ b/Assets/UnityBlenderControl/Editor/PieMenus/DrawModePieMenu.cs
@@ -10,7 +10,7 @@ public static class DrawModePieMenu {
         CreateEntry("Shaded Wireframe", "d_PreMatSphere", DrawCameraMode.TexturedWire),
     });
 
-    [ClutchShortcut("Draw Mode Pie Menu", typeof(SceneView), KeyCode.Z)]
+    [ClutchShortcut("Blender Controls/Draw Mode Pie Menu", typeof(SceneView), KeyCode.Z)]
     static void PerformPieMenu(ShortcutArguments arguments) {
         overlay.Perform(arguments);
     }

--- a/Assets/UnityBlenderControl/Editor/PieMenus/DrawModePieMenu.cs
+++ b/Assets/UnityBlenderControl/Editor/PieMenus/DrawModePieMenu.cs
@@ -1,0 +1,24 @@
+using JonasWischeropp.Unity.EditorTools.SceneView;
+using UnityEditor;
+using UnityEditor.ShortcutManagement;
+using UnityEngine;
+
+public static class DrawModePieMenu {
+    static PieMenu overlay = new PieMenu(new PieMenuEntry[]{
+        CreateEntry("Shaded", "TreeEditor.Material", DrawCameraMode.Normal),
+        CreateEntry("Wireframe", "TreeEditor.Geometry On", DrawCameraMode.Wireframe),
+        CreateEntry("Shaded Wireframe", "d_PreMatSphere", DrawCameraMode.TexturedWire),
+    });
+
+    [ClutchShortcut("Draw Mode Pie Menu", typeof(SceneView), KeyCode.Z)]
+    static void PerformPieMenu(ShortcutArguments arguments) {
+        overlay.Perform(arguments);
+    }
+
+    static PieMenuEntry CreateEntry(string name, string icon, DrawCameraMode mode) {
+        return new PieMenuEntry(name, icon,
+            () => SceneView.lastActiveSceneView.cameraMode = SceneView.GetBuiltinCameraMode(mode),
+            () => SceneView.lastActiveSceneView.cameraMode == SceneView.GetBuiltinCameraMode(mode)
+        );
+    }
+}

--- a/Assets/UnityBlenderControl/Editor/PieMenus/DrawModePieMenu.cs.meta
+++ b/Assets/UnityBlenderControl/Editor/PieMenus/DrawModePieMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e1046883929acd348b4b03df18ecea49

--- a/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs
+++ b/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs
@@ -15,7 +15,9 @@ public static class PivotPointPieMenu {
 
     [ClutchShortcut("Pivot Point Pie Menu", typeof(SceneView), KeyCode.Period)]
     static void PerformPieMenu(ShortcutArguments arguments) {
-        overlay.Perform(arguments);
+        if (BlenderManager.CurrentTransformMode == null) {
+            overlay.Perform(arguments);
+        }
     }
 
     static PieMenuEntry CreateEntry(string name, string icon, PivotPoint mode) {

--- a/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs
+++ b/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs
@@ -1,0 +1,25 @@
+using JonasWischeropp.Unity.EditorTools.SceneView;
+using UnityEditor;
+using UnityEditor.ShortcutManagement;
+using UnityEngine;
+using PivotPoint = BlenderManager.PivotPoint;
+
+public static class PivotPointPieMenu {
+    static PieMenu overlay = new PieMenu(new PieMenuEntry[]{
+        // TODO icons
+        CreateEntry("Individual Origins", "TreeEditor.Material", PivotPoint.IndividualOrigins),
+        CreateEntry("Bounding Box Center", "TreeEditor.Material", PivotPoint.BoundingBoxCenter),
+        CreateEntry("Active Element", "TreeEditor.Material", PivotPoint.ActiveElement),
+        CreateEntry("Media Point", "TreeEditor.Material", PivotPoint.MedianPoint),
+        CreateEntry("3D Cursor", "TreeEditor.Material", PivotPoint.ThreeDCursor),
+    });
+
+    [ClutchShortcut("Pivot Point Pie Menu", typeof(SceneView), KeyCode.Period)]
+    static void PerformPieMenu(ShortcutArguments arguments) {
+        overlay.Perform(arguments);
+    }
+
+    static PieMenuEntry CreateEntry(string name, string icon, PivotPoint mode) {
+        return new PieMenuEntry(name, icon, () => BlenderManager.CurrentPivotPoint = mode, () => BlenderManager.CurrentPivotPoint == mode);
+    }
+}

--- a/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs
+++ b/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs
@@ -8,6 +8,7 @@ public static class PivotPointPieMenu {
     static PieMenu overlay = new PieMenu(new PieMenuEntry[]{
         // TODO icons
         CreateEntry("Individual Origins", "TreeEditor.Material", PivotPoint.IndividualOrigins),
+        new PieMenuEntry("Only Location", "TreeEditor.Material", () => BlenderManager.LocationOnly = !BlenderManager.LocationOnly, () => BlenderManager.LocationOnly),
         CreateEntry("Bounding Box Center", "TreeEditor.Material", PivotPoint.BoundingBoxCenter),
         CreateEntry("Active Element", "TreeEditor.Material", PivotPoint.ActiveElement),
         CreateEntry("Media Point", "TreeEditor.Material", PivotPoint.MedianPoint),

--- a/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs
+++ b/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs
@@ -14,7 +14,7 @@ public static class PivotPointPieMenu {
         CreateEntry("Media Point", "TreeEditor.Material", PivotPoint.MedianPoint),
     });
 
-    [ClutchShortcut("Pivot Point Pie Menu", typeof(SceneView), KeyCode.Period)]
+    [ClutchShortcut("Blender Controls/Pivot Point Pie Menu", typeof(SceneView), KeyCode.Period)]
     static void PerformPieMenu(ShortcutArguments arguments) {
         if (BlenderManager.CurrentTransformMode == null) {
             overlay.Perform(arguments);

--- a/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs
+++ b/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs
@@ -11,7 +11,6 @@ public static class PivotPointPieMenu {
         CreateEntry("Bounding Box Center", "TreeEditor.Material", PivotPoint.BoundingBoxCenter),
         CreateEntry("Active Element", "TreeEditor.Material", PivotPoint.ActiveElement),
         CreateEntry("Media Point", "TreeEditor.Material", PivotPoint.MedianPoint),
-        CreateEntry("3D Cursor", "TreeEditor.Material", PivotPoint.ThreeDCursor),
     });
 
     [ClutchShortcut("Pivot Point Pie Menu", typeof(SceneView), KeyCode.Period)]

--- a/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs.meta
+++ b/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5bcde30208f4f5d4c92df8d668be5d26

--- a/Assets/UnityBlenderControl/Editor/Unity.UnityBlenderControl.Editor.asmdef
+++ b/Assets/UnityBlenderControl/Editor/Unity.UnityBlenderControl.Editor.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "Unity.UnityBlenderControl.Editor",
     "rootNamespace": "",
-    "references": [],
+    "references": [
+        "GUID:8dfebe96105e5dd9d8e90448f3bd3b73"
+    ],
     "includePlatforms": [
         "Editor"
     ],

--- a/Assets/UnityBlenderControl/package.json
+++ b/Assets/UnityBlenderControl/package.json
@@ -4,9 +4,7 @@
     "displayName": "Unity Blender Control",
     "description": "This is a Package for Unity to bring blender style of controling objects",
     "unity": "2022.3",
-    "dependencies": {
-        "wischeropp.jonas.scene-view-pie-menu": "https://github.com/JonasWischeropp/unity-scene-view-pie-menu.git#1.1.0"
-    },
+    "dependencies": { },
     "keywords": [
         "blender",
         "unity",

--- a/Assets/UnityBlenderControl/package.json
+++ b/Assets/UnityBlenderControl/package.json
@@ -4,7 +4,9 @@
     "displayName": "Unity Blender Control",
     "description": "This is a Package for Unity to bring blender style of controling objects",
     "unity": "2022.3",
-    "dependencies": {},
+    "dependencies": {
+        "wischeropp.jonas.scene-view-pie-menu": "https://github.com/JonasWischeropp/unity-scene-view-pie-menu.git#1.1.0"
+    },
     "keywords": [
         "blender",
         "unity",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Install with UPM (dependency and the package)
 ```bash
 https://github.com/JonasWischeropp/unity-scene-view-pie-menu.git#1.1.0
 ```
-5. Press `Install` add and wait to finish.
+5. Press `Install` and wait to finish.
 6. Repeat 3-5 with:
 ```bash
 https://github.com/RoxDevvv/Unity-Blender-Control-Style.git?path=/Assets/UnityBlenderControl

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-
-![Logo](https://raw.githubusercontent.com/RoxDevvv/Unity-Blender-Control-Style/Alpha/logo.png)
+<p align="center">
+<img src="https://raw.githubusercontent.com/RoxDevvv/Unity-Blender-Control-Style/Alpha/logo.png" alt="Logo">
+</p>
 
 
 # Unity Blender Controller
@@ -9,24 +10,27 @@ Unity Blender-Style Transform Plugin
 
 # Overview
 
-This Unity plugin aims to bring Blender-style transform controls to Unity, providing users with a familiar and intuitive way to manipulate objects within the scene. Inspired by Blender's 'G,S,R'  functionality, our plugin enables users to easily move, rotate, and scale objects using a similar workflow.
+This Unity plugin aims to bring Blender-style transform controls to Unity, providing users with a familiar and intuitive way to manipulate objects within the scene. Inspired by Blender's 'G,S,R' functionality, our plugin enables users to easily move, rotate, and scale objects using a similar workflow.
 
 
 ## Getting Started
 ## Installation
 
-Install with UPM
+Install with UPM (dependency and the package)
 
-
-  1 - Open your Unity project.
-  2 - Navigate to the Unity Package Manager (Window > Package Manager).
-  3 - Click the + button and select Add package from git url....
-  ```bash
-   https://github.com/RoxDevvv/Unity-Blender-Control-Style.git?path=/Assets/UnityBlenderControl
-  ```
-  4 - Press add wait to finish.
-  
-  5 - enjoy!
+1. Open your Unity project.
+2. Navigate to the Unity Package Manager (Window > Package Manager).
+3. Click the `+` button and select `Add package from git URL...`
+4. Paste:
+```bash
+https://github.com/JonasWischeropp/unity-scene-view-pie-menu.git#1.1.0
+```
+5. Press `Install` add and wait to finish.
+6. Repeat 3-5 with:
+```bash
+https://github.com/RoxDevvv/Unity-Blender-Control-Style.git?path=/Assets/UnityBlenderControl
+```
+7. enjoy!
 
     
 ## Usage/Examples


### PR DESCRIPTION
This pull request mainly adds the option to use different pivot points and some other small changes that are more or less related to this feature.

If you don't like any of the changes of this PR let me know.

# Pivot Point
<img width="723" height="332" alt="pivot point pie menu" src="https://github.com/user-attachments/assets/d2631f35-9a02-4755-83bc-6719683b517e" />

# Location Only
Add support for location only transformations. Toggled with the same pie menu, like in blender.

# Highlight Active Axis
When transforming objects in local space, multiple axis are shown and the one of the active object is show in a slightly different color now (like in blender). This is relevant for the rotation direction, because the active object defines the rotation direction.

# Draw Mode Pie Menu
I added the pie menu to change the render mode, because I thought it would be a nice to have.
<img width="695" height="215" alt="draw mode pie menu" src="https://github.com/user-attachments/assets/95030893-a3d8-4124-97b7-3a0cfb452488" />

# Dependency
I added a dependency to [JonasWischeropp/unity-scene-view-pie-menu](https://github.com/JonasWischeropp/unity-scene-view-pie-menu) for the pie menu. Unfortunately, the `dependencies` entry in `package.json` does not allow dependencies to packages for git.
[Unity Docs](https://docs.unity3d.com/Manual/upm-git.html):
> Note: You can’t specify Git dependencies
in a [package.json](https://docs.unity3d.com/Manual/upm-manifestPkg.html) file because the Package Manager doesn’t support Git dependencies between packages.

So for now, I have added instructions in the readme to install the package manually.

# TODO
Everything should be working, but I noticed some things that I want to mention / that might need to be addressed at some point:
- the pivot point pie menu doesn't have icons yet
- the move transform behaves a little weird (already before)
- the global scaling of multiple objects not aligned with coordinate axis is not perfect due to the sheering that would normally happen and does not exactly match Blender (but is now possible)
- there is some duplicated code (mainly between Rotate and Scale) due to the duplication of `PerObjectData`, should probably be refactored