### PR TITLE
Overhaul transform controls with key binding system, pie menus, and pivot point modes

### DIFF
--- a/Assets/UnityBlenderControl/CHANGELOG.md
+++ b/Assets/UnityBlenderControl/CHANGELOG.md
@@ -1,2 +1,38 @@
+## [0.1.0] - Unreleased
+
+### Added
+- Pivot point modes: Individual Origins, Median Point, Bounding Box Center, Active Element
+- Location-only transformation mode
+- Draw Mode pie menu (Shaded / Wireframe / Shaded Wireframe) via `D` key
+- Pivot Point pie menu via `.` (Period) key
+- Axis indicator lines for Rotate and Scale modes
+- Cursor icon changes during Rotate and Scale
+- Y/Z axis swap option in settings
+- Settings autosave via EditorPrefs
+- Floating point and backspace support in numeric input
+- Negative scale support
+- Key binding system with rebindable controls via control window
+
+### Changed
+- Transform modes now hook into `SceneView.duringSceneGui` instead of custom editor — fixes keybinding conflicts
+- Axis mode cycles through Unlocked → Global → Local via repeated axis key presses
+- Axis mode now uses Unity's `Tools.pivotRotation` and auto-reverts on exit
+- Rotation direction adapts based on view direction
+- Numeric input defaults to positive numbers
+- Consolidated key binding configuration into a grouped layout
+
+### Fixed
+- Rotation direction inverted depending on camera view
+- Rotation not working when mouse hasn't moved
+- Scaling with pivot point miscalculations
+- Position change calculation during rotation
+- Line-to-cursor rendering on different monitor scales
+- Key events not being consumed properly
+- Overlay appearing when pressing `S` (Scale)
+- Rotation by numeric angle
+- Cancel method on BlenderScale not fully reverting
+- Exception when entering numeric input without prior digits
+- Modifier keys (`Ctrl`/`Alt`/`Shift`) incorrectly triggering transforms
+
 ## [0.0.1] - 22 December 2023
- - Initial Version
+- Initial Version

--- a/Assets/UnityBlenderControl/Editor/BlenderManager.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEditor;
+using UnityEditor.ShortcutManagement;
 using UnityEngine;
 using static TransformModeManager;
 
@@ -68,6 +69,9 @@ public static class BlenderManager {
     public static float CurrentNumber = 0;
     public static bool MoveByNumber => !float.IsNaN(CurrentNumber);
 
+    private static bool drawModePieKeyHeld = false;
+    private static bool pivotPointPieKeyHeld = false;
+
     private static void Reset() {
         CurrentTransformMode = null;
         CurrentAxis = Axis.None;
@@ -110,12 +114,31 @@ public static class BlenderManager {
         };
     }
 
+    private static void HandlePieMenus() {
+        CheckPieMenuKey(KeyBindings.Action.DrawModePieMenu, ref drawModePieKeyHeld, DrawModePieMenu.Trigger);
+        CheckPieMenuKey(KeyBindings.Action.PivotPointPieMenu, ref pivotPointPieKeyHeld, PivotPointPieMenu.Trigger);
+    }
+
+    private static void CheckPieMenuKey(KeyBindings.Action action, ref bool keyHeld, Action<ShortcutStage> trigger) {
+        KeyCode boundKey = KeyBindings.GetBinding(action);
+        if (!keyHeld && Event.current.type == EventType.KeyDown && Event.current.keyCode == boundKey) {
+            keyHeld = true;
+            trigger(ShortcutStage.Begin);
+        }
+        else if (keyHeld && Event.current.type == EventType.KeyUp && Event.current.keyCode == boundKey) {
+            keyHeld = false;
+            trigger(ShortcutStage.End);
+        }
+    }
+
     private static void OnDuringSceneGUI(SceneView sv) {
         if (!isBlenderPluginEnabled)
             return;
 
         BlenderHelper.RightMouseHeldCheck();
         BlenderHelper.CheckSnap();
+
+        HandlePieMenus();
 
         foreach (var transformMode in TransformModes) {
             if (transformMode != CurrentTransformMode && transformMode.ShouldTrigger(Event.current)) {
@@ -132,12 +155,13 @@ public static class BlenderManager {
         }
 
         if (Event.current.type == EventType.KeyDown && !(Event.current.alt || Event.current.control)) {
-            Axis newAxis = Event.current.keyCode switch {
-                KeyCode.X => Axis.X,
-                KeyCode.Y => swapYAndZ ? Axis.Z : Axis.Y,
-                KeyCode.Z => swapYAndZ ? Axis.Y : Axis.Z,
-                _ => Axis.None
-            };
+            Axis newAxis = Axis.None;
+            if (Event.current.keyCode == KeyBindings.GetBinding(KeyBindings.Action.AxisX))
+                newAxis = Axis.X;
+            else if (Event.current.keyCode == KeyBindings.GetBinding(KeyBindings.Action.AxisY))
+                newAxis = swapYAndZ ? Axis.Z : Axis.Y;
+            else if (Event.current.keyCode == KeyBindings.GetBinding(KeyBindings.Action.AxisZ))
+                newAxis = swapYAndZ ? Axis.Y : Axis.Z;
             // OnlyOtherAxis = Event.current.shift;
             if (newAxis != Axis.None) {
                 if (CurrentAxis == Axis.None || newAxis == CurrentAxis) {

--- a/Assets/UnityBlenderControl/Editor/BlenderMove.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderMove.cs
@@ -15,7 +15,7 @@ public class BlenderMove : BlenderTransformMode {
     public Vector3 averagePosition;
 
     public override bool ShouldTrigger(Event evt) {
-        return BlenderHelper.ShouldTriggerSimple(evt, KeyCode.G);
+        return BlenderHelper.ShouldTriggerSimple(evt, KeyBindings.GetBinding(KeyBindings.Action.Move));
     }
 
     public override void Initialize() {

--- a/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderRotate.cs
@@ -18,7 +18,7 @@ public class BlenderRotate : BlenderTransformMode {
     Bounds bounds;
 
     public override bool ShouldTrigger(Event evt) {
-        return BlenderHelper.ShouldTriggerSimple(evt, KeyCode.R);
+        return BlenderHelper.ShouldTriggerSimple(evt, KeyBindings.GetBinding(KeyBindings.Action.Rotate));
     }
 
     public override void Initialize() {

--- a/Assets/UnityBlenderControl/Editor/BlenderScale.cs
+++ b/Assets/UnityBlenderControl/Editor/BlenderScale.cs
@@ -18,7 +18,7 @@ public class BlenderScale : BlenderTransformMode {
     Bounds bounds;
 
     public override bool ShouldTrigger(Event evt) {
-        return BlenderHelper.ShouldTriggerSimple(evt, KeyCode.S);
+        return BlenderHelper.ShouldTriggerSimple(evt, KeyBindings.GetBinding(KeyBindings.Action.Scale));
     }
 
     public override void Initialize() {

--- a/Assets/UnityBlenderControl/Editor/KeyBindings.cs
+++ b/Assets/UnityBlenderControl/Editor/KeyBindings.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+public static class KeyBindings
+{
+    public enum Action
+    {
+        Move,
+        Rotate,
+        Scale,
+        AxisX,
+        AxisY,
+        AxisZ,
+        DrawModePieMenu,
+        PivotPointPieMenu,
+    }
+
+    private static Dictionary<Action, KeyCode> bindings = new Dictionary<Action, KeyCode>();
+
+    private static readonly Dictionary<Action, KeyCode> defaults = new Dictionary<Action, KeyCode>
+    {
+        { Action.Move, KeyCode.G },
+        { Action.Rotate, KeyCode.R },
+        { Action.Scale, KeyCode.S },
+        { Action.AxisX, KeyCode.X },
+        { Action.AxisY, KeyCode.Y },
+        { Action.AxisZ, KeyCode.Z },
+        { Action.DrawModePieMenu, KeyCode.D },
+        { Action.PivotPointPieMenu, KeyCode.Period },
+    };
+
+    public static KeyCode GetBinding(Action action)
+    {
+        if (bindings.TryGetValue(action, out KeyCode key))
+            return key;
+        return defaults[action];
+    }
+
+    public static void SetBinding(Action action, KeyCode key)
+    {
+        bindings[action] = key;
+        Save();
+    }
+
+    public static void ResetToDefaults()
+    {
+        foreach (var kvp in defaults)
+            bindings[kvp.Key] = kvp.Value;
+        Save();
+    }
+
+    public static void Load()
+    {
+        foreach (Action action in Enum.GetValues(typeof(Action)))
+        {
+            string prefKey = $"BlenderControlKey_{action}";
+            int intVal = EditorPrefs.GetInt(prefKey, (int)defaults[action]);
+            bindings[action] = (KeyCode)intVal;
+        }
+    }
+
+    public static void Save()
+    {
+        foreach (var kvp in bindings)
+        {
+            EditorPrefs.SetInt($"BlenderControlKey_{kvp.Key}", (int)kvp.Value);
+        }
+    }
+
+    public static string ActionDisplayName(Action action)
+    {
+        return action switch
+        {
+            Action.Move => "Move (Grab)",
+            Action.Rotate => "Rotate",
+            Action.Scale => "Scale",
+            Action.AxisX => "Constrain X Axis",
+            Action.AxisY => "Constrain Y Axis",
+            Action.AxisZ => "Constrain Z Axis",
+            Action.DrawModePieMenu => "Draw Mode Pie Menu",
+            Action.PivotPointPieMenu => "Pivot Point Pie Menu",
+            _ => action.ToString(),
+        };
+    }
+}

--- a/Assets/UnityBlenderControl/Editor/KeyBindings.cs.meta
+++ b/Assets/UnityBlenderControl/Editor/KeyBindings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 401a8647b6b45b4469611d241db1cfea

--- a/Assets/UnityBlenderControl/Editor/PieMenus/DrawModePieMenu.cs
+++ b/Assets/UnityBlenderControl/Editor/PieMenus/DrawModePieMenu.cs
@@ -10,9 +10,8 @@ public static class DrawModePieMenu {
         CreateEntry("Shaded Wireframe", "d_PreMatSphere", DrawCameraMode.TexturedWire),
     });
 
-    [ClutchShortcut("Blender Controls/Draw Mode Pie Menu", typeof(SceneView), KeyCode.Z)]
-    static void PerformPieMenu(ShortcutArguments arguments) {
-        overlay.Perform(arguments);
+    public static void Trigger(ShortcutStage stage) {
+        overlay.Perform(new ShortcutArguments { stage = stage, context = SceneView.lastActiveSceneView });
     }
 
     static PieMenuEntry CreateEntry(string name, string icon, DrawCameraMode mode) {

--- a/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs
+++ b/Assets/UnityBlenderControl/Editor/PieMenus/PivotPointPieMenu.cs
@@ -14,10 +14,9 @@ public static class PivotPointPieMenu {
         CreateEntry("Media Point", "TreeEditor.Material", PivotPoint.MedianPoint),
     });
 
-    [ClutchShortcut("Blender Controls/Pivot Point Pie Menu", typeof(SceneView), KeyCode.Period)]
-    static void PerformPieMenu(ShortcutArguments arguments) {
+    public static void Trigger(ShortcutStage stage) {
         if (BlenderManager.CurrentTransformMode == null) {
-            overlay.Perform(arguments);
+            overlay.Perform(new ShortcutArguments { stage = stage, context = SceneView.lastActiveSceneView });
         }
     }
 

--- a/Assets/UnityBlenderControl/Editor/PluginControlWindow.cs
+++ b/Assets/UnityBlenderControl/Editor/PluginControlWindow.cs
@@ -1,31 +1,123 @@
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using static TransformModeManager;
 
 public class PluginControlWindow : EditorWindow
 {
+    private static KeyBindings.Action? pendingRebind = null;
+    private Vector2 scrollPos;
+
+    private static readonly KeyBindings.Action[] bindableActions = new KeyBindings.Action[]
+    {
+        KeyBindings.Action.Move, KeyBindings.Action.Rotate, KeyBindings.Action.Scale,
+        KeyBindings.Action.AxisX, KeyBindings.Action.AxisY, KeyBindings.Action.AxisZ,
+        KeyBindings.Action.DrawModePieMenu, KeyBindings.Action.PivotPointPieMenu,
+    };
+
     [MenuItem("Blender/Blender Control Window")]
     public static void ShowWindow()
     {
         GetWindow<PluginControlWindow>("Blender Plugin Control");
     }
+
     private void OnEnable()
     {
-        // Load the saved setting when the window is enabled
         LoadSettings();
+        pendingRebind = null;
     }
+
     private void OnGUI()
     {
         GUILayout.Label("Blender Plugin Control", EditorStyles.boldLabel);
-        
+
         EditorGUI.BeginChangeCheck();
 
         isBlenderPluginEnabled = EditorGUILayout.Toggle("Enable Plugin", isBlenderPluginEnabled);
         swapYAndZ = EditorGUILayout.Toggle("Swap Y and Z", swapYAndZ);
 
-        if (EditorGUI.EndChangeCheck()) {
-            // save settings if one of them was changed
+        if (EditorGUI.EndChangeCheck())
+        {
             SaveSettings();
         }
+
+        GUILayout.Space(10);
+        GUILayout.Label("Key Bindings", EditorStyles.boldLabel);
+        GUILayout.Space(4);
+
+        scrollPos = EditorGUILayout.BeginScrollView(scrollPos);
+
+        foreach (var action in bindableActions)
+        {
+            DrawKeyBindingRow(action);
+        }
+
+        GUILayout.Space(6);
+
+        if (GUILayout.Button("Reset Key Bindings to Defaults"))
+        {
+            KeyBindings.ResetToDefaults();
+        }
+
+        EditorGUILayout.EndScrollView();
+
+        if (pendingRebind.HasValue && Event.current.type == EventType.KeyDown)
+        {
+            KeyCode pressed = Event.current.keyCode;
+            if (pressed == KeyCode.Escape)
+            {
+                pendingRebind = null;
+                Repaint();
+                Event.current.Use();
+            }
+            else if (pressed != KeyCode.None
+                     && pressed != KeyCode.LeftControl && pressed != KeyCode.RightControl
+                     && pressed != KeyCode.LeftShift && pressed != KeyCode.RightShift
+                     && pressed != KeyCode.LeftAlt && pressed != KeyCode.RightAlt)
+            {
+                KeyBindings.SetBinding(pendingRebind.Value, pressed);
+                pendingRebind = null;
+                Repaint();
+                Event.current.Use();
+            }
+        }
+    }
+
+    private void DrawKeyBindingRow(KeyBindings.Action action)
+    {
+        EditorGUILayout.BeginHorizontal();
+        GUILayout.Label(KeyBindings.ActionDisplayName(action), GUILayout.Width(150));
+
+        bool isRebinding = pendingRebind == action;
+
+        if (isRebinding)
+        {
+            GUI.color = Color.yellow;
+            if (GUILayout.Button("Press a key...", GUILayout.Width(120)))
+            {
+                pendingRebind = null;
+                Repaint();
+            }
+            GUI.color = Color.white;
+        }
+        else
+        {
+            KeyCode currentKey = KeyBindings.GetBinding(action);
+
+            bool hasConflict = bindableActions.Any(a => a != action && KeyBindings.GetBinding(a) == currentKey);
+
+            if (hasConflict)
+                GUI.color = Color.red;
+
+            if (GUILayout.Button(currentKey.ToString(), GUILayout.Width(120)))
+            {
+                pendingRebind = action;
+                Repaint();
+            }
+
+            GUI.color = Color.white;
+        }
+
+        EditorGUILayout.EndHorizontal();
     }
 }

--- a/Assets/UnityBlenderControl/Editor/TransformModeManager.cs
+++ b/Assets/UnityBlenderControl/Editor/TransformModeManager.cs
@@ -11,7 +11,7 @@ public static class TransformModeManager
     internal static void LoadSettings() {
         isBlenderPluginEnabled = EditorPrefs.GetBool("BlenderControlPluginEnabled", true);
         swapYAndZ = EditorPrefs.GetBool("BlenderControlPluginSwapYAndZ", false);
-        
+        KeyBindings.Load();
     }
     
     internal static void SaveSettings()

--- a/README.md
+++ b/README.md
@@ -1,69 +1,130 @@
 <p align="center">
-<img src="https://raw.githubusercontent.com/RoxDevvv/Unity-Blender-Control-Style/Alpha/logo.png" alt="Logo">
+<img src="https://raw.githubusercontent.com/RoxDevvv/Unity-Blender-Control-Style/Alpha/logo.png" alt="Unity Blender Control Style" width="400">
 </p>
 
+<h1 align="center">Unity Blender Control Style</h1>
+<p align="center">
+  <strong>Blender-style transform controls for the Unity Editor</strong>
+</p>
 
-# Unity Blender Controller
+<p align="center">
+  <img src="https://raw.githubusercontent.com/RoxDevvv/Unity-Blender-Control-Style/Alpha/Preview.gif" alt="Preview">
+</p>
 
-Unity Blender-Style Transform Plugin
+## Overview
 
+Unity Blender Control Style brings Blender's iconic **Grab (G), Rotate (R), Scale (S)** workflow into the Unity Scene View. Select an object, press a key, and transform with mouse movement, axis constraints, or numeric input — just like in Blender.
 
-# Overview
+## Features
 
-This Unity plugin aims to bring Blender-style transform controls to Unity, providing users with a familiar and intuitive way to manipulate objects within the scene. Inspired by Blender's 'G,S,R' functionality, our plugin enables users to easily move, rotate, and scale objects using a similar workflow.
+| Feature | Description |
+|---|---|
+| **Grab / Move** | Press `G` to move objects freely or along axes |
+| **Rotate** | Press `R` to rotate around the view axis or a constrained axis |
+| **Scale** | Press `S` to scale uniformly or along a single axis |
+| **Axis Constraints** | Press `X`, `Y`, or `Z` during a transform to lock to that axis |
+| **Axis Lock Modes** | Toggle between Unlocked → Global → Local by pressing the same axis key again |
+| **Numeric Input** | Type a number during a transform for precise values (e.g., `G`, `5`, `Enter` moves 5 units) |
+| **Snap While Transforming** | Hold `Ctrl` during a transform to snap to grid increments |
+| **Undo Support** | All transforms register with Unity's undo system |
+| **Pie Menus** | Press `D` for draw mode (Shaded / Wireframe / Shaded Wireframe), `.` for pivot point selection |
+| **Pivot Point Modes** | Individual Origins, Median Point, Bounding Box Center, Active Element |
+| **Customizable Key Bindings** | All keys are rebindable via the control window |
+| **Plugin Toggle** | Enable/disable the plugin without removing it |
+| **Y/Z Swap** | Option to swap Y and Z axis keys for different coordination preferences |
+| **Scene GUI Overlays** | Visual axis lines and cursor changes during transforms |
 
+## Quick Start
 
-## Getting Started
+Select an object in the Scene View, then:
+
+| Key | Action |
+|---|---|
+| `G` | Grab / Move |
+| `R` | Rotate |
+| `S` | Scale |
+| `X` / `Y` / `Z` | Constrain to axis (press again to toggle Global/Local/Unlocked) |
+| `D` | Draw Mode pie menu |
+| `.` (Period) | Pivot Point pie menu |
+| `Ctrl` (hold) | Snap during transform |
+| `Enter` / Left Click | Confirm transform |
+| `Esc` / Right Click | Cancel transform |
+
+> **Numeric input**: After pressing `G`/`R`/`S`, type a number (e.g., `5`, `-3.5`) and press `Enter` to apply an exact value. Use `Backspace` to correct.
+
 ## Installation
 
-Install with UPM (dependency and the package)
+> **Requirement**: This package depends on [unity-scene-view-pie-menu](https://github.com/JonasWischeropp/unity-scene-view-pie-menu). Install it first.
 
-1. Open your Unity project.
-2. Navigate to the Unity Package Manager (Window > Package Manager).
-3. Click the `+` button and select `Add package from git URL...`
-4. Paste:
-```bash
-https://github.com/JonasWischeropp/unity-scene-view-pie-menu.git#1.1.0
+### Via Unity Package Manager (UPM)
+
+1. Open **Window > Package Manager**
+2. Click **+** → **Add package from git URL...**
+3. Add the dependency:
+   ```
+   https://github.com/JonasWischeropp/unity-scene-view-pie-menu.git#1.1.0
+   ```
+4. Click **Install** and wait
+5. Repeat with the plugin itself:
+   ```
+   https://github.com/RoxDevvv/Unity-Blender-Control-Style.git?path=/Assets/UnityBlenderControl
+   ```
+6. Click **Install**
+
+## Configuration
+
+Open **Blender > Blender Control Window** to:
+
+- Toggle the plugin on/off
+- Swap Y and Z axis keys
+- Rebind all keyboard shortcuts
+
+Settings persist between sessions via `EditorPrefs`.
+
+## Known Issues
+
+- Selecting GameObjects from the Hierarchy while in a transform mode may not work as expected.
+  - **Workaround**: Click on the Scene View tab after selecting from the Hierarchy to re-focus.
+
+## Requirements
+
+- Unity **2022.3** or newer
+- [unity-scene-view-pie-menu](https://github.com/JonasWischeropp/unity-scene-view-pie-menu) v1.1.0
+
+## Package Structure
+
 ```
-5. Press `Install` and wait to finish.
-6. Repeat 3-5 with:
-```bash
-https://github.com/RoxDevvv/Unity-Blender-Control-Style.git?path=/Assets/UnityBlenderControl
+Assets/UnityBlenderControl/
+├── Editor/
+│   ├── BlenderManager.cs          # Core manager - handles input, axis modes, scene GUI
+│   ├── BlenderTransformMode.cs    # Abstract base class for transform modes
+│   ├── BlenderMove.cs             # Grab/Move implementation
+│   ├── BlenderRotate.cs           # Rotate implementation
+│   ├── BlenderScale.cs            # Scale implementation
+│   ├── BlenderHelper.cs           # Utility functions (snap, unit parsing, input helpers)
+│   ├── KeyBindings.cs             # Configurable key binding system
+│   ├── TransformModeManager.cs    # Settings persistence (enable, swap Y/Z)
+│   ├── PluginControlWindow.cs     # Editor window for configuration
+│   └── PieMenus/
+│       ├── DrawModePieMenu.cs     # Draw mode selector (wireframe/shaded/etc.)
+│       └── PivotPointPieMenu.cs   # Pivot point selector
+└── Scenes/
+    └── SampleScene.unity          # Example scene
 ```
-7. enjoy!
-
-    
-## Usage/Examples
-
-```
-Select an object in the Unity Scene.
-Press the designated key ('G','S','R') to initiate the grab/transform mode.
-Move the mouse to manipulate the object. OR Type number and minus key if you wish to control the direction of rotation, scale, or movement.
-Release the key to confirm the transformation.
-Press right mouse to cancel changes
-```
-
-
-## Preview
-
-![caption](https://raw.githubusercontent.com/RoxDevvv/Unity-Blender-Control-Style/Alpha/Preview.gif)
-
-## Known Issue 
-Selecting gameobject from the hierarchy will not work 
-Workaround : after selecting gameobject from hierarchy press the tab of scene view.
-
-## Support
-
-For support, email aminelaaraf@gmail.com.
-
 
 ## Contributing
 
-We welcome contributions! Feel free to submit issues, pull requests, or reach out with suggestions.
+Contributions are welcome! Submit issues, feature requests, or pull requests on [GitHub](https://github.com/RoxDevvv/Unity-Blender-Control-Style).
+
 ## License
 
-This project is licensed under the MIT License.
+[MIT](Assets/UnityBlenderControl/LICENSE.md)
 
+## Support
 
-## 💸 Donation
-[![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/roxdevvv)
+- Email: aminelaaraf@gmail.com
+- [Ko-fi](https://ko-fi.com/roxdevvv)
+
+## Changelog
+
+See [CHANGELOG.md](Assets/UnityBlenderControl/CHANGELOG.md).


### PR DESCRIPTION
### Changes

- **Key Binding System** — new `KeyBindings.cs` with fully rebindable keys (G/R/S/X/Y/Z/D/.), conflict detection, and persistence via EditorPrefs
- **Plugin Control Window** — rewrite with scrollable key binding UI, pending rebind flow, and grouped layout
- **Pie Menu Integration** — Draw Mode pie menu (`D` key) and Pivot Point pie menu (`.` key) in `BlenderManager`
- **Pivot Point Modes** — Individual Origins, Median Point, Bounding Box Center, Active Element via `GetTransformationCenter()`
- **Axis Constraint Refactor** — uses `KeyBindings.GetBinding()` instead of hardcoded `KeyCode`, respects Y/Z swap
- **README** — comprehensive rewrite with features table, quick-start key reference, installation, and package structure
- **CHANGELOG** — full update with all changes since v0.0.1 from git history